### PR TITLE
Re-initialize API client on login

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,7 +25,14 @@ export default function App() {
             <Container maxWidth="md" sx={{ my: 4 }}>
               <Routes>
                 <Route path="/" element={<HomePage />} />
-                <Route path="/search" element={<SearchPage />} />
+                <Route
+                  path="/search"
+                  element={
+                    <RouteGuard>
+                      <SearchPage />
+                    </RouteGuard>
+                  }
+                />
                 <Route
                   path="/journeys"
                   element={


### PR DESCRIPTION
The GraphQL API client was initialized only on a page reload. This meant that after a login the client stayed un-authenticated. Solved by setting the auth token when it's not yet set.