### PR TITLE
Fix broken signup and other small fixes

### DIFF
--- a/backend/src/model/trainPriceMonitor.ts
+++ b/backend/src/model/trainPriceMonitor.ts
@@ -23,7 +23,6 @@ const User = new Entity({
     familyName: { type: 'string', required: true },
     profilePicture: { type: 'string' },
     emailNotificationsEnabled: { type: 'boolean', required: true, default: true },
-    activated: { type: 'boolean', required: true, default: false },
   },
 } as const);
 

--- a/backend/src/resolvers/resolvers.ts
+++ b/backend/src/resolvers/resolvers.ts
@@ -5,7 +5,6 @@ import {
   userResolvers,
   updateUserProfilePicture,
   createUser,
-  activateUser,
   updateUserSettings,
 } from './user';
 import {
@@ -30,7 +29,6 @@ const resolvers: Resolvers = {
   Mutation: {
     updateUserProfilePicture: updateUserProfilePicture,
     createUser: createUser,
-    activateUser: activateUser,
     updateUserSettings: updateUserSettings,
     monitorJourney: monitorJourney,
     updateJourneyMonitors: updateJourneyMonitors,

--- a/backend/src/schema/generated/resolvers.generated.ts
+++ b/backend/src/schema/generated/resolvers.generated.ts
@@ -180,12 +180,6 @@ export type MutationResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']
 > = {
-  activateUser?: Resolver<
-    Maybe<ResolversTypes['User']>,
-    ParentType,
-    ContextType,
-    RequireFields<MutationActivateUserArgs, 'id'>
-  >;
   createUser?: Resolver<
     Maybe<ResolversTypes['User']>,
     ParentType,
@@ -302,7 +296,6 @@ export type UserResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']
 > = {
-  activated?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   emailNotificationsEnabled?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   familyName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/backend/src/schema/generated/typeDefs.generated.ts
+++ b/backend/src/schema/generated/typeDefs.generated.ts
@@ -56,7 +56,6 @@ export type Location = {
 
 export type Mutation = {
   __typename?: 'Mutation';
-  activateUser?: Maybe<User>;
   createUser?: Maybe<User>;
   deleteJourneyMonitor?: Maybe<JourneyMonitor>;
   markNotificationAsRead?: Maybe<Notification>;
@@ -66,10 +65,6 @@ export type Mutation = {
   updateJourneyMonitors?: Maybe<Scalars['Int']['output']>;
   updateUserProfilePicture?: Maybe<User>;
   updateUserSettings?: Maybe<User>;
-};
-
-export type MutationActivateUserArgs = {
-  id: Scalars['ID']['input'];
 };
 
 export type MutationCreateUserArgs = {
@@ -170,7 +165,6 @@ export type QueryUserProfilePicturePresignedUrlArgs = {
 
 export type User = {
   __typename?: 'User';
-  activated: Scalars['Boolean']['output'];
   email: Scalars['String']['output'];
   emailNotificationsEnabled: Scalars['Boolean']['output'];
   familyName: Scalars['String']['output'];

--- a/backend/src/schema/schema.graphql
+++ b/backend/src/schema/schema.graphql
@@ -13,7 +13,6 @@ type User {
   email: String!
   profilePicture: String
   emailNotificationsEnabled: Boolean!
-  activated: Boolean!
   notifications(limit: Int, read: Boolean): [Notification]
   journeyMonitors(limit: Int): [JourneyMonitor]
 }
@@ -41,10 +40,6 @@ extend type Mutation {
 
 extend type Mutation {
   createUser(id: ID!, givenName: String!, familyName: String!, email: String!): User
-}
-
-extend type Mutation {
-  activateUser(id: ID!): User
 }
 
 extend type Mutation {

--- a/frontend/src/api/user.tsx
+++ b/frontend/src/api/user.tsx
@@ -17,15 +17,6 @@ export const CreateUser = gql`
   }
 `;
 
-export const ActivateUser = gql`
-  mutation ($id: ID!) {
-    activateUser(id: $id) {
-      id
-      activated
-    }
-  }
-`;
-
 export const UpdateUserSettings = gql`
   mutation ($id: ID!, $emailNotificationsEnabled: Boolean!) {
     updateUserSettings(id: $id, emailNotificationsEnabled: $emailNotificationsEnabled) {
@@ -35,10 +26,10 @@ export const UpdateUserSettings = gql`
   }
 `;
 
-export const UserActivationStatusQuery = gql`
+export const UserExistsQuery = gql`
   query ($id: ID!) {
     user(id: $id) {
-      activated
+      id
     }
   }
 `;

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -64,7 +64,9 @@ const Header = () => {
   // Schedule the notification query to run every 30 seconds
   useEffect(() => {
     const intervalId = setInterval(() => {
-      reexecuteUserNotificationsQuery({ requestPolicy: 'network-only' });
+      if (user?.['custom:id']) {
+        reexecuteUserNotificationsQuery({ requestPolicy: 'network-only' });
+      }
     }, 30000);
 
     // Clean up the interval when the component is unmounted

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -34,7 +34,7 @@ const Header = () => {
   const [{ stale, data: userNotificationsResult }, reexecuteUserNotificationsQuery] = useQuery({
     query: UserNotificationsQuery,
     variables: { id: user?.['custom:id'], notificationsLimit: 8, read: false },
-    pause: !user,
+    pause: !user?.['custom:id'],
   });
   const [, markNotificationAsRead] = useMutation(MarkNotificationAsRead);
 

--- a/frontend/src/components/SearchResult.tsx
+++ b/frontend/src/components/SearchResult.tsx
@@ -57,8 +57,11 @@ const SearchResult: React.FC<Props> = ({ searchData, searchResult }) => {
 
   const handleCloseModal = () => {
     setOpenModal(false);
-    setSelectedJourney(null); // Clear selected journey when the modal is closed
-    setLimitPrice(''); // Clear limit price when the modal is closed
+
+    setTimeout(() => {
+      setSelectedJourney(null); // Clear selected journey when the modal is closed
+      setLimitPrice(''); // Clear limit price when the modal is closed
+    }, 100);
   };
 
   const handleConfirmWatch = () => {

--- a/frontend/src/components/SignupModal.tsx
+++ b/frontend/src/components/SignupModal.tsx
@@ -47,6 +47,8 @@ const SignupModal: React.FC<Props> = ({ open, onClose }) => {
     }
   };
 
+  const isSignupDisabled = !givenName || !email || !password;
+
   return (
     <Dialog open={open} onClose={onClose}>
       <DialogTitle>Sign Up</DialogTitle>
@@ -61,6 +63,7 @@ const SignupModal: React.FC<Props> = ({ open, onClose }) => {
           value={givenName}
           onChange={(e) => setGivenName(e.target.value)}
           onKeyPress={handleKeyPress}
+          required
         />
         <TextField
           margin="dense"
@@ -80,6 +83,7 @@ const SignupModal: React.FC<Props> = ({ open, onClose }) => {
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           onKeyPress={handleKeyPress}
+          required
         />
         <TextField
           margin="dense"
@@ -89,11 +93,12 @@ const SignupModal: React.FC<Props> = ({ open, onClose }) => {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           onKeyPress={handleKeyPress}
+          required
         />
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>
-        <Button onClick={handleSignUp} variant="contained" color="primary">
+        <Button onClick={handleSignUp} variant="contained" color="primary" disabled={isSignupDisabled}>
           Sign Up
         </Button>
       </DialogActions>

--- a/frontend/src/components/SignupModal.tsx
+++ b/frontend/src/components/SignupModal.tsx
@@ -3,8 +3,6 @@ import React, { useState } from 'react';
 import useAlert from '../hooks/useAlert';
 import { AlertSeverity } from '../providers/AlertProvider';
 import { signUp } from '../utils/auth';
-import { CreateUser } from '../api/user';
-import { useMutation } from 'urql';
 import { v4 as uuidv4 } from 'uuid';
 
 interface Props {
@@ -18,7 +16,6 @@ const SignupModal: React.FC<Props> = ({ open, onClose }) => {
   const [familyName, setFamilyName] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const { addAlert } = useAlert();
-  const [, createUser] = useMutation(CreateUser);
 
   const handleSignUp = async () => {
     const userId = uuidv4();
@@ -28,15 +25,6 @@ const SignupModal: React.FC<Props> = ({ open, onClose }) => {
       addAlert(err.message, AlertSeverity.Error);
       return;
     }
-    createUser({ id: userId, email, familyName, givenName })
-      .then((result) => {
-        if (result.error) {
-          addAlert(result.error.message, AlertSeverity.Error);
-        }
-      })
-      .catch((reason) => {
-        console.log(reason);
-      });
     addAlert('Sign up successful! Please check your emails and confirm your account.', AlertSeverity.Success);
     onClose();
   };

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -18,7 +18,7 @@ const HomePage: React.FC<Props> = () => {
   const [userActivatedResult] = useQuery({
     query: UserActivationStatusQuery,
     variables: { id: user?.['custom:id'] },
-    pause: !user,
+    pause: !user?.['custom:id'],
   });
   const [, activateUser] = useMutation(ActivateUser);
 

--- a/frontend/src/pages/JourneysPage.tsx
+++ b/frontend/src/pages/JourneysPage.tsx
@@ -41,7 +41,7 @@ const JourneysPage: React.FC = () => {
   const [{ data: userJourneysResult, fetching: userJourneysFetching }, reexecuteUserJourneysQuery] = useQuery({
     query: UserJourneysQuery,
     variables: { id: user?.['custom:id'] },
-    pause: !user,
+    pause: !user?.['custom:id'],
   });
   const [{ fetching: deleteJourneyMonitorFetching }, deleteJourneyMonitor] = useMutation(DeleteJourneyMonitor);
 

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -20,7 +20,7 @@ const ProfilePage: React.FC = () => {
   const [{ data: userSettingsData, fetching: userSettingsFetching }] = useQuery({
     query: UserSettingsQuery,
     variables: { id: user?.['custom:id'] },
-    pause: !user,
+    pause: !user?.['custom:id'],
   });
   const [, updateUserSettings] = useMutation(UpdateUserSettings);
 

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -25,7 +25,7 @@ function AuthProvider({ children }: { children: React.ReactNode }) {
   const [userProfilePictureUrlResult, reexecuteUserProfilePictureUrlQuery] = useQuery({
     query: UserProfilePictureUrlQuery,
     variables: { id: user?.['custom:id'] },
-    pause: !user,
+    pause: !user?.['custom:id'],
   });
 
   const getCurrentUser = async () => {

--- a/frontend/src/utils/apiClient.tsx
+++ b/frontend/src/utils/apiClient.tsx
@@ -23,7 +23,7 @@ const cognitoAuthExchange = authExchange(async (utils) => {
       });
     },
     didAuthError(error, _operation) {
-      return error.response.status === 401;
+      return error.response?.status && error.response?.status === 401;
     },
     async refreshAuth() {
       token = await getJwtToken();

--- a/frontend/src/utils/auth.tsx
+++ b/frontend/src/utils/auth.tsx
@@ -120,7 +120,6 @@ export async function getCurrentUser() {
     const cognitoUser = userPool.getCurrentUser();
 
     if (!cognitoUser) {
-      reject(new Error('No user found'));
       return;
     }
 


### PR DESCRIPTION
- Improve pausing of queries depending on user ID
- Add timeout before unsetting selected journey when closing watch dialog
- Make mandatory fields required when signing up and disable Signup button
- Fix signup and profile picture loading
- Only query for notifications when logged in
- Don't throw error when user is not logged in