### PR TITLE
fix: clean up PRICE_ALERT notifications when journey expires (#40)

### DIFF
--- a/backend/src/resolvers/journey.ts
+++ b/backend/src/resolvers/journey.ts
@@ -184,10 +184,10 @@ export const updateJourneyMonitor: NonNullable<MutationResolvers['updateJourneyM
       .send();
     context.cache.invalidate([{ typename: 'Notification' }]);
 
-    await sendNotificationEmailIfEnabled(context, args.userId, notificationId);
-
     // Clean up any existing PRICE_ALERT notifications for this journey
     await deletePriceAlertNotificationsForJourney(context, args.userId, args.journeyId);
+
+    await sendNotificationEmailIfEnabled(context, args.userId, notificationId);
 
     return journeyMonitor;
   }
@@ -278,9 +278,11 @@ async function deletePriceAlertNotificationsForJourney(context: GraphQLContext, 
   });
 
   if (toDelete && toDelete.length > 0) {
-    for (const notification of toDelete) {
-      await context.entities.Notification.build(DeleteItemCommand).key({ userId, id: notification.id }).send();
-    }
+    await Promise.all(
+      toDelete.map((notification) =>
+        context.entities.Notification.build(DeleteItemCommand).key({ userId, id: notification.id }).send()
+      )
+    );
     context.cache.invalidate([{ typename: 'Notification' }]);
     Logger.info(`Deleted ${toDelete.length} PRICE_ALERT notifications for journey`);
   }

--- a/backend/src/resolvers/journey.ts
+++ b/backend/src/resolvers/journey.ts
@@ -186,6 +186,9 @@ export const updateJourneyMonitor: NonNullable<MutationResolvers['updateJourneyM
 
     await sendNotificationEmailIfEnabled(context, args.userId, notificationId);
 
+    // Clean up any existing PRICE_ALERT notifications for this journey
+    await deletePriceAlertNotificationsForJourney(context, args.userId, args.journeyId);
+
     return journeyMonitor;
   }
 
@@ -253,6 +256,35 @@ export const updateJourneyMonitor: NonNullable<MutationResolvers['updateJourneyM
 
   return journeyMonitor;
 };
+
+async function deletePriceAlertNotificationsForJourney(context: GraphQLContext, userId: string, journeyId: string) {
+  const { Items: priceAlertNotifications } = await context.entities.TrainPriceMonitorTable.build(QueryCommand)
+    .entities(context.entities.Notification)
+    .query({ partition: `USER#${userId}` })
+    .options({
+      filters: {
+        Notification: { attr: 'type', eq: NOTIFICATION_TYPES.PRICE_ALERT.name },
+      },
+    })
+    .send();
+
+  const toDelete = priceAlertNotifications?.filter((item: { data?: string }) => {
+    if (!item.data) return false;
+    try {
+      return JSON.parse(item.data).journeyId === journeyId;
+    } catch {
+      return false;
+    }
+  });
+
+  if (toDelete && toDelete.length > 0) {
+    for (const notification of toDelete) {
+      await context.entities.Notification.build(DeleteItemCommand).key({ userId, id: notification.id }).send();
+    }
+    context.cache.invalidate([{ typename: 'Notification' }]);
+    Logger.info(`Deleted ${toDelete.length} PRICE_ALERT notifications for journey`);
+  }
+}
 
 async function sendNotificationEmailIfEnabled(context: GraphQLContext, userId: string, notificationId: string) {
   // Get setting for email notifications for user from database


### PR DESCRIPTION
## Problem

When `updateJourneyMonitor` detected an expired journey, it deleted the journey record and created a `JOURNEY_EXPIRED` notification — but any existing `PRICE_ALERT` notification for that journey was left as an orphan in DynamoDB. This is inconsistent with `deleteJourneyMonitor`, which already performs this cleanup.

## Fix

Extracted a private helper `deletePriceAlertNotificationsForJourney` that:
1. Queries `PRICE_ALERT` notifications for the user
2. Filters client-side by `data.journeyId`
3. Deletes each match and invalidates the Notification cache

The helper is called in `updateJourneyMonitor` immediately after the expiry email is sent, before returning.

## Changes

- `backend/src/resolvers/journey.ts` — new helper + call site in the expiry path

Fixes #40