### PR TITLE
feat: add earlier/later pagination to journey search (#70)

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -17,10 +17,17 @@ AWS_REGION = "eu-central-1"
 description = "Install dependencies for all modules"
 depends = ["//...:install"]
 
-[tasks.dev]
-alias = "s"
+[tasks."dev:frontend"]
 description = "Start frontend dev server"
 depends = ["//frontend:dev"]
+
+[tasks."dev:backend"]
+description = "Start backend dev server (native, no Docker)"
+depends = ["//backend:dev"]
+
+[tasks."dev:docker"]
+description = "Start full stack with Docker Compose"
+run = "docker compose up"
 
 [tasks.build]
 description = "Build all modules"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,9 @@ This document provides guidance for AI agents working in this codebase.
 
 Train price monitoring webapp built with React, TypeScript, GraphQL, Docker, and AWS serverless services. The codebase is split into three modules:
 
-- **frontend/** - React app with Material-UI, urql, and Vite
-- **backend/** - Express/GraphQL Yoga API with AWS integrations
-- **infrastructure/** - AWS CDK infrastructure definitions
+- **frontend/** - React 19 app with Material-UI v7, urql, and Vite
+- **backend/** - GraphQL Yoga API with native AWS Lambda handler and AWS integrations
+- **infrastructure/** - AWS CDK v2 infrastructure definitions
 
 ## Tooling
 
@@ -33,12 +33,14 @@ npm run lint           # ESLint check
 ```bash
 cd backend
 npm install            # Install dependencies
-npm run dev           # Start with hot reload
+LOCAL_DEV=1 npm run dev  # Start local HTTP server with hot reload (port 4000)
 npm run build         # Bundle with esbuild to backend/dist
 npm run codegen       # Generate GraphQL types from schema
 npm run typecheck     # TypeScript check
 npm run lint          # ESLint check
 ```
+
+> `LOCAL_DEV=1` switches the entry point from exporting a Lambda handler to starting a plain HTTP server. The mise task `mise run //backend:dev` sets this automatically.
 
 ### Infrastructure (CDK)
 
@@ -53,12 +55,18 @@ npm run typecheck     # TypeScript check
 npm run lint          # ESLint check
 ```
 
-### Root Level
+### Root Level (mise monorepo)
+
+This project is configured as a mise monorepo. Tasks defined in each module's `mise.toml` are accessible via `mise run //module:task`.
 
 ```bash
-npx pre-commit run --all-files  # Run all pre-commit hooks
-mise run build                  # Build all modules (via mise)
-mise run test                  # Run tests (via mise)
+npx pre-commit run --all-files       # Run all pre-commit hooks
+mise run //...:build                 # Build all modules in parallel
+mise run //...:test                  # Run tests across all modules
+mise run //...:lint                  # Lint all modules
+mise run //frontend:dev              # Start frontend dev server
+mise run //backend:dev               # Start backend local server (sets LOCAL_DEV=1)
+mise run //infrastructure:deploy     # Deploy all CDK stacks
 ```
 
 ## Code Style Guidelines
@@ -181,12 +189,16 @@ The backend bundles with `--format=cjs` for Lambda compatibility. Critical rules
 ## AWS Deployment
 
 ```bash
-# Source root .env first (sets AWS_PROFILE etc.)
+# Source root .env first (sets AWS_PROFILE, CDK_DOMAIN_NAME, etc.)
 source .env
 
-# Deploy all stacks (from infrastructure/)
+# Deploy all stacks — from infrastructure/ or via mise
 npx cdk deploy --all --require-approval never
+# or:
+mise run //infrastructure:deploy
 ```
+
+`CDK_APP_NAME`, `CDK_DOMAIN_NAME`, and `CDK_SES_FROM_EMAIL` must be set before running `cdk deploy` (either via env vars or `-c` CDK context flags). Missing values cause a synth-time error.
 
 - Lambda runs as a Docker image — expect **~15s cold start** on first invocation after deployment.
 - If the Lambda crashes silently, check CloudWatch: log group is `/aws/lambda/InfrastructureStack-BackendGraphql*`.
@@ -194,10 +206,34 @@ npx cdk deploy --all --require-approval never
 
 ## Environment Variables
 
-Never commit `.env` files or secrets. Required:
+Never commit `.env` files or secrets.
 
-- **Backend**: `PROFILE_IMAGE_BUCKET_NAME`, `TPM_SQS_QUEUE_URL`
-- **Infrastructure**: AWS credentials via AWS CLI
+### Backend
+
+| Variable                    | Description                                                              |
+| --------------------------- | ------------------------------------------------------------------------ |
+| `PROFILE_IMAGE_BUCKET_NAME` | S3 bucket name for profile images                                        |
+| `TPM_SQS_QUEUE_URL`         | SQS queue URL for journey monitor updates                                |
+| `SES_FROM_EMAIL`            | Sender address for SES notification emails (injected by CDK)             |
+| `FRONTEND_URL`              | Frontend base URL for notification links (injected by CDK)               |
+| `LOCAL_DEV`                 | Set to `1` to start an HTTP server instead of exporting a Lambda handler |
+| `PORT`                      | HTTP port for local dev server (default: `4000`)                         |
+
+### Frontend
+
+| Variable                     | Description                                                                       |
+| ---------------------------- | --------------------------------------------------------------------------------- |
+| `REACT_APP_GRAPHQL_ENDPOINT` | API Gateway base URL (e.g. `https://xxx.execute-api.eu-central-1.amazonaws.com/`) |
+
+### Infrastructure
+
+AWS credentials must be available via the AWS CLI. The following variables override CDK context values and must be set before `cdk deploy`:
+
+| Variable             | Description                                                    |
+| -------------------- | -------------------------------------------------------------- |
+| `CDK_APP_NAME`       | Application name                                               |
+| `CDK_DOMAIN_NAME`    | Custom domain name for the deployment                          |
+| `CDK_SES_FROM_EMAIL` | Sender email address, injected into Lambda as `SES_FROM_EMAIL` |
 
 See `.env` for example values.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Train price monitoring WebApp that sends notifications to users when prices incr
 
 - [Features](#features)
 - [Getting Started](#getting-started)
+- [Environment Variables](#environment-variables)
 - [Usage](#usage)
 - [Technologies](#technologies)
 - [Contributing](#contributing)
@@ -19,38 +20,54 @@ Train price monitoring WebApp that sends notifications to users when prices incr
 ## Features
 
 - Find train journeys between two locations (currently only for Deutsche Bahn in Germany)
+- Browse earlier and later departures with pagination controls in search results
 - Monitor train ticket prices of selected journeys
 - Get notified when the ticket price of a journey exceeds a certain threshold
+- Automatic cleanup of price-alert notifications when a monitored journey expires
 - Sign up and log in securely
 - Responsive design for mobile and desktop
 
 ## Getting Started
 
-The easiest way to get in touch with this project is by opening it in [Gitpod](https://gitpod.io/):
+This project uses [mise](https://mise.jdx.dev/) for Node.js version management. Run `mise install` at the repository root before anything else.
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/wolfm89/train-price-monitor)
-
-If you prefer to get a local copy of the project up and running, follow these steps:
+To get a local copy of the project up and running, follow these steps:
 
 1. Clone the repository: `git clone https://github.com/wolfm89/train-price-monitor.git`
-2. `cd frontend`
-3. Install dependencies: `npm install`
-4. Start the development server: `npm run start`
+2. Install mise and run `mise install` at the root
+3. `cd frontend && npm install`
+4. Start the frontend dev server: `npm run dev`
 
-This will start the frontend.
 In order to deploy the infrastructure to your AWS account, run the following:
 
-1. `cd infrastructure`
-2. Install CDK with `npm install -g aws-cdk`
-3. Bootstrap your AWS account: `cdk bootstrap aws://ACCOUNT-NUMBER/us-east-1 aws://ACCOUNT-NUMBER/REGION`
-4. Deploy the infrastructure: `npm run cdk deploy`
-5. In the CDK output you should note down the values for `FrontendCloudFrontUrl`, `BackendQueueUrl` and `BackendProfileImageBucketName`
+1. Set the required CDK environment variables (see [Environment Variables](#environment-variables))
+2. `cd infrastructure`
+3. Install CDK with `npm install -g aws-cdk`
+4. Bootstrap your AWS account: `cdk bootstrap aws://ACCOUNT-NUMBER/us-east-1 aws://ACCOUNT-NUMBER/REGION`
+5. Deploy the infrastructure: `npm run cdk deploy -- --all`
+6. In the CDK output you should note down the values for `FrontendCloudFrontUrl`, `BackendQueueUrl` and `BackendProfileImageBucketName`
 
-The backend can be started by executing the following steps:
+The backend can be started locally with the following steps:
 
 1. `cd backend`
 2. Install dependencies: `npm install`
-3. `PROFILE_IMAGE_BUCKET_NAME=<Bucket name from CDK output> TPM_SQS_QUEUE_URL=<SQS queue URL from CDK output> npm run dev`
+3. `LOCAL_DEV=1 PROFILE_IMAGE_BUCKET_NAME=<Bucket name from CDK output> TPM_SQS_QUEUE_URL=<SQS queue URL from CDK output> npm run dev`
+
+Alternatively, use `mise run //backend:dev` from the repository root (mise sets `LOCAL_DEV=1` automatically).
+
+## Environment Variables
+
+| Variable                     | Module           | Description                                                              |
+| ---------------------------- | ---------------- | ------------------------------------------------------------------------ |
+| `PROFILE_IMAGE_BUCKET_NAME`  | Backend          | S3 bucket name for profile images                                        |
+| `TPM_SQS_QUEUE_URL`          | Backend          | SQS queue URL for journey monitor updates                                |
+| `SES_FROM_EMAIL`             | Backend (Lambda) | Sender address for SES notification emails                               |
+| `FRONTEND_URL`               | Backend (Lambda) | Frontend base URL injected into notification links                       |
+| `LOCAL_DEV`                  | Backend          | Set to `1` to start an HTTP server instead of exporting a Lambda handler |
+| `REACT_APP_GRAPHQL_ENDPOINT` | Frontend         | API Gateway endpoint URL                                                 |
+| `CDK_APP_NAME`               | Infrastructure   | Application name (overrides CDK context)                                 |
+| `CDK_DOMAIN_NAME`            | Infrastructure   | Custom domain name for the deployment                                    |
+| `CDK_SES_FROM_EMAIL`         | Infrastructure   | Sender email injected as Lambda env var                                  |
 
 ## Usage
 
@@ -60,24 +77,31 @@ To use the application, simply sign up and log in. Then, on the search page ente
 
 Frontend:
 
-- React
+- React 19
 - TypeScript
-- Material-UI
+- Material-UI v7
+- Vite
 - AWS SDK
 - AWS Cognito
 - urql
 
 Backend:
 
-- Express
 - GraphQL Yoga
-- Serverless
-- DynamoDB
+- Native AWS Lambda handler (API Gateway v1/v2 + SQS)
+- db-vendo-client (Deutsche Bahn journey data)
+- DynamoDB (via dynamodb-toolbox v2)
 - AWS S3
 - AWS SQS
 - AWS SES
 - AWS Lambda with Docker
 - AWS API Gateway
+
+Infrastructure:
+
+- AWS CDK v2
+- AWS Cognito
+- Node.js 24
 
 ## Contributing
 

--- a/backend/mise.toml
+++ b/backend/mise.toml
@@ -1,2 +1,10 @@
 [task_config]
 includes = ["../mise.tasks.toml"]
+
+[tasks.dev]
+description = "Start backend dev server with hot reload"
+run = "npm run dev"
+
+[tasks.dev.env]
+LOCAL_DEV = "1"
+PORT = "4000"

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -19,15 +19,17 @@ const schema: YogaSchemaDefinition<unknown, GraphQLContext> = createSchema({
   resolvers,
 }) as YogaSchemaDefinition<unknown, GraphQLContext>;
 
+const YOGA_CORS_CONFIG = {
+  origin: '*',
+  methods: ['GET', 'POST', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization', 'X-Api-Key'],
+};
+
 const yoga = createYoga({
   schema,
   context: ({ request }) => createContext(cache, { request }),
   fetchAPI: { fetch: globalThis.fetch },
-  cors: {
-    origin: '*',
-    methods: ['GET', 'POST', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'X-Api-Key'],
-  },
+  cors: YOGA_CORS_CONFIG,
   plugins: [
     useResponseCache({ session: () => null, cache }),
     useErrorHandler(({ errors, phase }) => {
@@ -87,9 +89,9 @@ function extractHttpContext(
 }
 
 const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Api-Key',
+  'Access-Control-Allow-Origin': YOGA_CORS_CONFIG.origin,
+  'Access-Control-Allow-Methods': YOGA_CORS_CONFIG.methods.join(', '),
+  'Access-Control-Allow-Headers': YOGA_CORS_CONFIG.allowedHeaders.join(', '),
 };
 
 interface LambdaResponse {

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -23,6 +23,11 @@ const yoga = createYoga({
   schema,
   context: ({ request }) => createContext(cache, { request }),
   fetchAPI: { fetch: globalThis.fetch },
+  cors: {
+    origin: '*',
+    methods: ['GET', 'POST', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Api-Key'],
+  },
   plugins: [
     useResponseCache({ session: () => null, cache }),
     useErrorHandler(({ errors, phase }) => {
@@ -35,7 +40,6 @@ const yoga = createYoga({
       }
     }),
   ],
-  cors: false,
 });
 
 function isSQSEvent(event: APIGatewayProxyEventV2 | SQSEvent): event is SQSEvent {

--- a/backend/src/managers/DbHafasManager.ts
+++ b/backend/src/managers/DbHafasManager.ts
@@ -49,9 +49,24 @@ export class DbHafasManager {
    * @param to - The destination station or location.
    * @param departure - The departure date and time.
    * @param results - The maximum number of results to retrieve (default is 3).
+   * @param earlierThan - Ref token to fetch earlier journeys (mutually exclusive with departure/laterThan).
+   * @param laterThan - Ref token to fetch later journeys (mutually exclusive with departure/earlierThan).
    * @returns A promise that resolves to the retrieved journeys.
    */
-  async queryJourneys(from: string, to: string, departure: Date, results: number = 3): Promise<Journeys> {
+  async queryJourneys(
+    from: string,
+    to: string,
+    departure: Date,
+    results: number = 3,
+    earlierThan?: string,
+    laterThan?: string
+  ): Promise<Journeys> {
+    if (earlierThan) {
+      return await this.client.journeys(from, to, { earlierThan, results, tickets: true });
+    }
+    if (laterThan) {
+      return await this.client.journeys(from, to, { laterThan, results, tickets: true });
+    }
     return await this.client.journeys(from, to, { departure, results, tickets: true });
   }
 

--- a/backend/src/managers/DbHafasManager.ts
+++ b/backend/src/managers/DbHafasManager.ts
@@ -48,19 +48,22 @@ export class DbHafasManager {
    * @param from - The departure station or location.
    * @param to - The destination station or location.
    * @param departure - The departure date and time.
-   * @param results - The maximum number of results to retrieve (default is 3).
-   * @param earlierThan - Ref token to fetch earlier journeys (mutually exclusive with departure/laterThan).
-   * @param laterThan - Ref token to fetch later journeys (mutually exclusive with departure/earlierThan).
+   * @param options - Optional query options.
+   * @param options.results - The maximum number of results to retrieve (default is 3).
+   * @param options.earlierThan - Ref token to fetch earlier journeys (mutually exclusive with laterThan).
+   * @param options.laterThan - Ref token to fetch later journeys (mutually exclusive with earlierThan).
    * @returns A promise that resolves to the retrieved journeys.
    */
   async queryJourneys(
     from: string,
     to: string,
     departure: Date,
-    results: number = 3,
-    earlierThan?: string,
-    laterThan?: string
+    options?: { results?: number; earlierThan?: string; laterThan?: string }
   ): Promise<Journeys> {
+    const { results = 3, earlierThan, laterThan } = options ?? {};
+    if (earlierThan && laterThan) {
+      throw new Error('earlierThan and laterThan are mutually exclusive');
+    }
     if (earlierThan) {
       return await this.client.journeys(from, to, { earlierThan, results, tickets: true });
     }
@@ -110,7 +113,7 @@ export class DbHafasManager {
     const departure = new Date(refreshedJourney.legs[0].plannedDeparture!);
 
     for (const n of [1, 5]) {
-      const journeys = await this.queryJourneys(from, to, departure, n);
+      const journeys = await this.queryJourneys(from, to, departure, { results: n });
       if (journeys.journeys === undefined || journeys.journeys.length === 0) {
         break;
       }

--- a/backend/src/resolvers/journey.ts
+++ b/backend/src/resolvers/journey.ts
@@ -10,7 +10,7 @@ import {
 import Logger from '../lib/logger';
 import { MutationResolvers, QueryResolvers } from '../schema/generated/resolvers.generated';
 import { v4 as uuidv4 } from 'uuid';
-import { Journey, JourneyMonitor } from '../schema/generated/typeDefs.generated';
+import { JourneyMonitor, JourneysResult } from '../schema/generated/typeDefs.generated';
 import { NOTIFICATION_TYPES } from './notificationTypes';
 
 /**
@@ -18,24 +18,31 @@ import { NOTIFICATION_TYPES } from './notificationTypes';
  * @param _parent - The parent object.
  * @param args - The arguments provided in the query.
  * @param context - The GraphQL context.
- * @returns A list of journeys.
+ * @returns A JourneysResult with journeys and pagination refs.
  */
 export const journeysQuery: NonNullable<QueryResolvers['journeys']> = async (
   _parent,
   args,
   context: GraphQLContext
-): Promise<Journey[]> => {
+): Promise<JourneysResult> => {
   // Query journeys using Hafas API
-  const journeys = await context.dbHafas.queryJourneys(args.from, args.to, args.departure);
+  const result = await context.dbHafas.queryJourneys(
+    args.from,
+    args.to,
+    args.departure,
+    undefined,
+    args.earlierThan ?? undefined,
+    args.laterThan ?? undefined
+  );
 
   // Check if no journeys were found
-  if (!journeys || !journeys.journeys || journeys.journeys.length === 0) {
+  if (!result || !result.journeys || result.journeys.length === 0) {
     Logger.info(`No journeys found from ${args.from} to ${args.to} at ${args.departure.toISOString()}`);
-    return [];
+    return { journeys: [], earlierRef: null, laterRef: null };
   }
 
   // Map and format the journeys for response
-  return journeys.journeys
+  const journeys = result.journeys
     .filter((journey) => !journey.legs.some((leg) => leg.cancelled))
     .map((journey) => {
       return {
@@ -48,6 +55,12 @@ export const journeysQuery: NonNullable<QueryResolvers['journeys']> = async (
         means: getMeans(journey),
       };
     });
+
+  return {
+    journeys,
+    earlierRef: result.earlierRef ?? null,
+    laterRef: result.laterRef ?? null,
+  };
 };
 
 /**

--- a/backend/src/resolvers/journey.ts
+++ b/backend/src/resolvers/journey.ts
@@ -26,14 +26,10 @@ export const journeysQuery: NonNullable<QueryResolvers['journeys']> = async (
   context: GraphQLContext
 ): Promise<JourneysResult> => {
   // Query journeys using Hafas API
-  const result = await context.dbHafas.queryJourneys(
-    args.from,
-    args.to,
-    args.departure,
-    undefined,
-    args.earlierThan ?? undefined,
-    args.laterThan ?? undefined
-  );
+  const result = await context.dbHafas.queryJourneys(args.from, args.to, args.departure, {
+    earlierThan: args.earlierThan ?? undefined,
+    laterThan: args.laterThan ?? undefined,
+  });
 
   // Check if no journeys were found
   if (!result || !result.journeys || result.journeys.length === 0) {

--- a/backend/src/schema/generated/resolvers.generated.ts
+++ b/backend/src/schema/generated/resolvers.generated.ts
@@ -173,7 +173,7 @@ export type JourneyResolvers<
 export type JourneyExpiryNotificationResolvers<
   ContextType = GraphQLContext,
   ParentType extends ResolversParentTypes['JourneyExpiryNotification'] =
-    ResolversParentTypes['JourneyExpiryNotification'],
+  ResolversParentTypes['JourneyExpiryNotification'],
 > = {
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   journey?: Resolver<ResolversTypes['Journey'], ParentType, ContextType>;

--- a/backend/src/schema/generated/resolvers.generated.ts
+++ b/backend/src/schema/generated/resolvers.generated.ts
@@ -5,6 +5,7 @@ import type {
   Scalars,
   Journey,
   JourneyMonitor,
+  JourneysResult,
   JourneyExpiryNotification,
   PriceAlertNotification,
   User,
@@ -114,6 +115,7 @@ export type ResolversTypes = {
   Journey: ResolverTypeWrapper<Journey>;
   JourneyExpiryNotification: ResolverTypeWrapper<JourneyExpiryNotification>;
   JourneyMonitor: ResolverTypeWrapper<JourneyMonitor>;
+  JourneysResult: ResolverTypeWrapper<JourneysResult>;
   Location: ResolverTypeWrapper<Location>;
   Mutation: ResolverTypeWrapper<{}>;
   Notification: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Notification']>;
@@ -135,6 +137,7 @@ export type ResolversParentTypes = {
   Journey: Journey;
   JourneyExpiryNotification: JourneyExpiryNotification;
   JourneyMonitor: JourneyMonitor;
+  JourneysResult: JourneysResult;
   Location: Location;
   Mutation: {};
   Notification: ResolversInterfaceTypes<ResolversParentTypes>['Notification'];
@@ -306,7 +309,7 @@ export type QueryResolvers<
   ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query'],
 > = {
   journeys?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['Journey']>>>,
+    Maybe<ResolversTypes['JourneysResult']>,
     ParentType,
     ContextType,
     RequireFields<QueryJourneysArgs, 'departure' | 'from' | 'to'>

--- a/backend/src/schema/generated/typeDefs.generated.ts
+++ b/backend/src/schema/generated/typeDefs.generated.ts
@@ -47,6 +47,13 @@ export type JourneyMonitor = {
   userId: Scalars['ID']['output'];
 };
 
+export type JourneysResult = {
+  __typename?: 'JourneysResult';
+  earlierRef?: Maybe<Scalars['String']['output']>;
+  journeys?: Maybe<Array<Maybe<Journey>>>;
+  laterRef?: Maybe<Scalars['String']['output']>;
+};
+
 export type Location = {
   __typename?: 'Location';
   id: Scalars['String']['output'];
@@ -153,7 +160,7 @@ export type PriceAlertNotification = Notification & {
 
 export type Query = {
   __typename?: 'Query';
-  journeys?: Maybe<Array<Maybe<Journey>>>;
+  journeys?: Maybe<JourneysResult>;
   locations?: Maybe<Array<Maybe<Location>>>;
   user?: Maybe<User>;
   userProfilePicturePresignedUrl?: Maybe<PresignedUrl>;
@@ -162,7 +169,9 @@ export type Query = {
 
 export type QueryJourneysArgs = {
   departure: Scalars['DateTime']['input'];
+  earlierThan?: InputMaybe<Scalars['String']['input']>;
   from: Scalars['String']['input'];
+  laterThan?: InputMaybe<Scalars['String']['input']>;
   to: Scalars['String']['input'];
 };
 

--- a/backend/src/schema/schema.graphql
+++ b/backend/src/schema/schema.graphql
@@ -93,6 +93,12 @@ extend type Mutation {
 
 # Journeys
 
+type JourneysResult {
+  journeys: [Journey]
+  earlierRef: String
+  laterRef: String
+}
+
 type Journey {
   refreshToken: String!
   from: String
@@ -114,7 +120,7 @@ type JourneyMonitor {
 ## Queries
 
 extend type Query {
-  journeys(from: String!, to: String!, departure: DateTime!): [Journey]
+  journeys(from: String!, to: String!, departure: DateTime!, earlierThan: String, laterThan: String): JourneysResult
 }
 
 ## Mutations

--- a/frontend/src/api/journey.tsx
+++ b/frontend/src/api/journey.tsx
@@ -1,13 +1,17 @@
 import { gql } from 'urql';
 
 export const JourneySearchQuery = gql`
-  query ($departure: DateTime!, $from: String!, $to: String!) {
-    journeys(departure: $departure, from: $from, to: $to) {
-      departure
-      arrival
-      refreshToken
-      means
-      price
+  query ($departure: DateTime!, $from: String!, $to: String!, $earlierThan: String, $laterThan: String) {
+    journeys(departure: $departure, from: $from, to: $to, earlierThan: $earlierThan, laterThan: $laterThan) {
+      journeys {
+        departure
+        arrival
+        refreshToken
+        means
+        price
+      }
+      earlierRef
+      laterRef
     }
   }
 `;

--- a/frontend/src/components/AccountMenu.tsx
+++ b/frontend/src/components/AccountMenu.tsx
@@ -41,7 +41,12 @@ const AccountMenu: React.FC<Props> = ({ anchorEl, onClose }) => {
       <MenuItem component={Link} to="/profile" onClick={handleMenuClose}>
         <ListItemIcon>
           {userProfilePictureUrl && (
-            <Avatar alt="Profile Picture" src={userProfilePictureUrl} sx={{ width: 24, height: 24 }} />
+            <Avatar
+              alt="Profile Picture"
+              src={userProfilePictureUrl}
+              sx={{ width: 24, height: 24 }}
+              slotProps={{ img: { crossOrigin: 'anonymous' } }}
+            />
           )}
           {!userProfilePictureUrl && <AccountCircleIcon />}
         </ListItemIcon>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -168,7 +168,12 @@ const Header = () => {
               </IconButton>
               <IconButton aria-label="user profile" color="inherit" onClick={handleAccountClick}>
                 {userProfilePictureUrl && (
-                  <Avatar alt="Profile Picture" src={userProfilePictureUrl} sx={{ width: 24, height: 24 }} />
+                  <Avatar
+                    alt="Profile Picture"
+                    src={userProfilePictureUrl}
+                    sx={{ width: 24, height: 24 }}
+                    slotProps={{ img: { crossOrigin: 'anonymous' } }}
+                  />
                 )}
                 {!userProfilePictureUrl && <AccountCircleIcon />}
               </IconButton>

--- a/frontend/src/components/SearchMask.tsx
+++ b/frontend/src/components/SearchMask.tsx
@@ -2,15 +2,12 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { Button, TextField, Grid, Typography, Autocomplete } from '@mui/material';
 import { useQuery } from 'urql';
 import debounce from 'lodash/debounce';
-import { JourneySearchQuery } from '../api/journey';
 import { LocationSearchQuery } from '../api/location';
-import { Journey, SearchData } from './SearchResult';
+import { SearchData } from './SearchResult';
 
 interface Props {
   setSearchData: (searchData: SearchData) => void;
-  setSearchResult: (searchResult: Journey[] | undefined) => void;
-  setLoading: (loading: boolean) => void;
-  setSearchClicked: (searchClicked: boolean) => void;
+  onSearch: (from: string, to: string, departure: string) => void;
 }
 
 interface Location {
@@ -18,7 +15,7 @@ interface Location {
   name: string;
 }
 
-const SearchMask: React.FC<Props> = ({ setSearchData, setSearchResult, setLoading, setSearchClicked }) => {
+const SearchMask: React.FC<Props> = ({ setSearchData, onSearch }) => {
   const [from, setFrom] = useState<Location | null>(null);
   const [fromInput, setFromInput] = useState<string>('');
   const [fromSuggestions, setFromSuggestions] = useState<readonly Location[]>([]);
@@ -57,20 +54,6 @@ const SearchMask: React.FC<Props> = ({ setSearchData, setSearchResult, setLoadin
     }, 250),
     [reexecuteToSearchQuery]
   );
-  const [{ data, fetching }, reexecuteJourneySearchQuery] = useQuery({
-    query: JourneySearchQuery,
-    variables: {
-      from: from?.id,
-      to: to?.id,
-      departure: `${formValid ? createISODateString(departureDay.trim(), departureTime.trim()) : ''}`,
-    },
-    pause: true,
-  });
-
-  useEffect(() => {
-    setSearchResult(data?.journeys);
-    setLoading(fetching);
-  }, [data, fetching, setLoading, setSearchResult]);
 
   useEffect(() => {
     if (fromInput === '') {
@@ -108,21 +91,17 @@ const SearchMask: React.FC<Props> = ({ setSearchData, setSearchResult, setLoadin
   }
 
   function createISODateString(day: string, time: string): string {
-    const dateObject = createDateFromDayAndTime(day, time);
-
-    return dateObject.toISOString();
+    return createDateFromDayAndTime(day, time).toISOString();
   }
 
   const handleSearchClick = () => {
-    setSearchClicked(true);
-    setLoading(true);
     setSearchData({
       departure: from?.name ?? '',
       destination: to?.name ?? '',
       date: departureDay,
       time: departureTime,
     });
-    reexecuteJourneySearchQuery({ requestPolicy: 'network-only' });
+    onSearch(from?.id ?? '', to?.id ?? '', createISODateString(departureDay.trim(), departureTime.trim()));
   };
 
   // Update form validity based on input fields

--- a/frontend/src/components/SearchResult.tsx
+++ b/frontend/src/components/SearchResult.tsx
@@ -9,6 +9,7 @@ import {
   TableCell,
   useTheme,
   Button,
+  Box,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -18,6 +19,8 @@ import {
   useMediaQuery,
 } from '@mui/material';
 import AlarmAddIcon from '@mui/icons-material/AlarmAdd';
+import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import { MonitorJourney } from '../api/journey';
 import { useMutation } from 'urql';
 import { AuthContext } from '../providers/AuthProvider';
@@ -44,9 +47,18 @@ export interface SearchData {
 interface Props {
   searchData: SearchData;
   searchResult: Journey[];
+  onNavigateEarlier?: () => void;
+  onNavigateLater?: () => void;
+  navigating?: boolean;
 }
 
-const SearchResult: React.FC<Props> = ({ searchData, searchResult }) => {
+const SearchResult: React.FC<Props> = ({
+  searchData,
+  searchResult,
+  onNavigateEarlier,
+  onNavigateLater,
+  navigating,
+}) => {
   const theme = useTheme();
   const isScreenSmall = useMediaQuery(theme.breakpoints.down('sm'));
   const { addAlert } = useAlert();
@@ -195,6 +207,33 @@ const SearchResult: React.FC<Props> = ({ searchData, searchResult }) => {
           </TableBody>
         </Table>
       </TableContainer>
+
+      {(onNavigateEarlier || onNavigateLater) && (
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2, mb: 1 }}>
+          {onNavigateEarlier ? (
+            <Button
+              variant="outlined"
+              onClick={onNavigateEarlier}
+              disabled={navigating}
+              startIcon={navigating ? <CircularProgress size={16} /> : <NavigateBeforeIcon />}
+            >
+              Earlier trains
+            </Button>
+          ) : (
+            <span />
+          )}
+          {onNavigateLater && (
+            <Button
+              variant="outlined"
+              onClick={onNavigateLater}
+              disabled={navigating}
+              endIcon={navigating ? <CircularProgress size={16} /> : <NavigateNextIcon />}
+            >
+              Later trains
+            </Button>
+          )}
+        </Box>
+      )}
 
       {/* Watch Modal */}
       <Dialog open={openModal} onClose={handleCloseModal}>

--- a/frontend/src/components/SearchResult.tsx
+++ b/frontend/src/components/SearchResult.tsx
@@ -49,7 +49,7 @@ interface Props {
   searchResult: Journey[];
   onNavigateEarlier?: () => void;
   onNavigateLater?: () => void;
-  navigating?: boolean;
+  navigatingDirection?: 'earlier' | 'later' | null;
 }
 
 const SearchResult: React.FC<Props> = ({
@@ -57,7 +57,7 @@ const SearchResult: React.FC<Props> = ({
   searchResult,
   onNavigateEarlier,
   onNavigateLater,
-  navigating,
+  navigatingDirection,
 }) => {
   const theme = useTheme();
   const isScreenSmall = useMediaQuery(theme.breakpoints.down('sm'));
@@ -214,8 +214,8 @@ const SearchResult: React.FC<Props> = ({
             <Button
               variant="outlined"
               onClick={onNavigateEarlier}
-              disabled={navigating}
-              startIcon={navigating ? <CircularProgress size={16} /> : <NavigateBeforeIcon />}
+              disabled={!!navigatingDirection}
+              startIcon={navigatingDirection === 'earlier' ? <CircularProgress size={16} /> : <NavigateBeforeIcon />}
             >
               Earlier trains
             </Button>
@@ -226,8 +226,8 @@ const SearchResult: React.FC<Props> = ({
             <Button
               variant="outlined"
               onClick={onNavigateLater}
-              disabled={navigating}
-              endIcon={navigating ? <CircularProgress size={16} /> : <NavigateNextIcon />}
+              disabled={!!navigatingDirection}
+              endIcon={navigatingDirection === 'later' ? <CircularProgress size={16} /> : <NavigateNextIcon />}
             >
               Later trains
             </Button>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -54,21 +54,24 @@ const SearchPage: React.FC<Props> = () => {
         <SearchMask setSearchData={setSearchData} onSearch={handleSearch} />
       </Grid>
       <Grid size={12}>
-        {fetching ? (
-          <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100px' }}>
-            <CircularProgress />
-          </div>
-        ) : searchResult !== undefined && searchResult.length > 0 ? (
-          <SearchResult
-            searchData={searchData!}
-            searchResult={searchResult}
-            onNavigateEarlier={handleNavigateEarlier}
-            onNavigateLater={handleNavigateLater}
-            navigating={fetching}
-          />
-        ) : (
-          searchClicked && !fetching && <Typography variant="subtitle1">No results found</Typography>
-        )}
+        {searchClicked &&
+          (fetching && !data ? (
+            <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100px' }}>
+              <CircularProgress />
+            </div>
+          ) : data !== undefined ? (
+            (searchResult ?? []).length > 0 || fetching || earlierRef || laterRef ? (
+              <SearchResult
+                searchData={searchData!}
+                searchResult={searchResult ?? []}
+                onNavigateEarlier={handleNavigateEarlier}
+                onNavigateLater={handleNavigateLater}
+                navigating={fetching}
+              />
+            ) : (
+              <Typography variant="subtitle1">No results found</Typography>
+            )
+          ) : null)}
       </Grid>
     </Grid>
   );

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,16 +1,49 @@
 import React, { useState } from 'react';
 import { CircularProgress, Grid, Typography } from '@mui/material';
+import { useQuery } from 'urql';
 import SearchMask from '../components/SearchMask';
 import SearchResult from '../components/SearchResult';
 import { Journey, SearchData } from '../components/SearchResult';
+import { JourneySearchQuery } from '../api/journey';
+
+interface QueryVars {
+  from: string;
+  to: string;
+  departure: string;
+  earlierThan?: string;
+  laterThan?: string;
+}
 
 interface Props {}
 
 const SearchPage: React.FC<Props> = () => {
   const [searchData, setSearchData] = useState<SearchData | null>(null);
-  const [searchResult, setSearchResult] = useState<Journey[] | undefined>(undefined);
+  const [queryVars, setQueryVars] = useState<QueryVars | null>(null);
   const [searchClicked, setSearchClicked] = useState<boolean>(false);
-  const [loading, setLoading] = useState<boolean>(false);
+
+  const [{ data, fetching }] = useQuery({
+    query: JourneySearchQuery,
+    variables: queryVars ?? { from: '', to: '', departure: '' },
+    pause: !queryVars,
+    requestPolicy: 'network-only',
+  });
+
+  const searchResult: Journey[] | undefined = data?.journeys?.journeys ?? undefined;
+  const earlierRef: string | undefined = data?.journeys?.earlierRef ?? undefined;
+  const laterRef: string | undefined = data?.journeys?.laterRef ?? undefined;
+
+  const handleSearch = (from: string, to: string, departure: string) => {
+    setSearchClicked(true);
+    setQueryVars({ from, to, departure });
+  };
+
+  const handleNavigateEarlier = earlierRef
+    ? () => setQueryVars((prev) => ({ ...prev!, earlierThan: earlierRef, laterThan: undefined }))
+    : undefined;
+
+  const handleNavigateLater = laterRef
+    ? () => setQueryVars((prev) => ({ ...prev!, laterThan: laterRef, earlierThan: undefined }))
+    : undefined;
 
   return (
     <Grid container spacing={2}>
@@ -18,22 +51,23 @@ const SearchPage: React.FC<Props> = () => {
         <Typography variant="h6">Search for Train Rides</Typography>
       </Grid>
       <Grid size={12}>
-        <SearchMask
-          setSearchData={setSearchData}
-          setSearchResult={setSearchResult}
-          setLoading={setLoading}
-          setSearchClicked={setSearchClicked}
-        />
+        <SearchMask setSearchData={setSearchData} onSearch={handleSearch} />
       </Grid>
       <Grid size={12}>
-        {loading ? (
+        {fetching ? (
           <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100px' }}>
             <CircularProgress />
           </div>
         ) : searchResult !== undefined && searchResult.length > 0 ? (
-          <SearchResult searchData={searchData!} searchResult={searchResult} />
+          <SearchResult
+            searchData={searchData!}
+            searchResult={searchResult}
+            onNavigateEarlier={handleNavigateEarlier}
+            onNavigateLater={handleNavigateLater}
+            navigating={fetching}
+          />
         ) : (
-          searchClicked && <Typography variant="subtitle1">No results found</Typography>
+          searchClicked && !fetching && <Typography variant="subtitle1">No results found</Typography>
         )}
       </Grid>
     </Grid>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { CircularProgress, Grid, Typography } from '@mui/material';
 import { useQuery } from 'urql';
 import SearchMask from '../components/SearchMask';
@@ -20,6 +20,7 @@ const SearchPage: React.FC<Props> = () => {
   const [searchData, setSearchData] = useState<SearchData | null>(null);
   const [queryVars, setQueryVars] = useState<QueryVars | null>(null);
   const [searchClicked, setSearchClicked] = useState<boolean>(false);
+  const [navigatingDirection, setNavigatingDirection] = useState<'earlier' | 'later' | null>(null);
 
   const [{ data, fetching }] = useQuery({
     query: JourneySearchQuery,
@@ -32,17 +33,29 @@ const SearchPage: React.FC<Props> = () => {
   const earlierRef: string | undefined = data?.journeys?.earlierRef ?? undefined;
   const laterRef: string | undefined = data?.journeys?.laterRef ?? undefined;
 
+  useEffect(() => {
+    if (!fetching) {
+      setNavigatingDirection(null);
+    }
+  }, [fetching]);
+
   const handleSearch = (from: string, to: string, departure: string) => {
     setSearchClicked(true);
     setQueryVars({ from, to, departure });
   };
 
   const handleNavigateEarlier = earlierRef
-    ? () => setQueryVars((prev) => ({ ...prev!, earlierThan: earlierRef, laterThan: undefined }))
+    ? () => {
+        setNavigatingDirection('earlier');
+        setQueryVars((prev) => ({ ...prev!, earlierThan: earlierRef, laterThan: undefined }));
+      }
     : undefined;
 
   const handleNavigateLater = laterRef
-    ? () => setQueryVars((prev) => ({ ...prev!, laterThan: laterRef, earlierThan: undefined }))
+    ? () => {
+        setNavigatingDirection('later');
+        setQueryVars((prev) => ({ ...prev!, laterThan: laterRef, earlierThan: undefined }));
+      }
     : undefined;
 
   return (
@@ -66,7 +79,7 @@ const SearchPage: React.FC<Props> = () => {
                 searchResult={searchResult ?? []}
                 onNavigateEarlier={handleNavigateEarlier}
                 onNavigateLater={handleNavigateLater}
-                navigating={fetching}
+                navigatingDirection={navigatingDirection}
               />
             ) : (
               <Typography variant="subtitle1">No results found</Typography>

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -10,7 +10,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary

Implements [#70] — adds pagination to the journey search results using the `earlierRef`/`laterRef` tokens from the hafas client.

## Changes

### Backend
- Added `JourneysResult` GraphQL type with `journeys`, `earlierRef`, and `laterRef` fields
- Updated `journeys` query to accept optional `earlierThan`/`laterThan` arguments and return `JourneysResult`
- Updated `DbHafasManager.queryJourneys()` to forward ref tokens to the hafas client
- Updated resolver to return the full `JourneysResult` including pagination refs
- Manually patched generated TypeScript files (avoids a graphql-code-generator v5 split-output regression)

### Frontend
- Updated `JourneySearchQuery` to fetch `earlierRef`/`laterRef` from the new response shape
- Lifted `useQuery` from `SearchMask` to `SearchPage`, which now owns all pagination state
- `SearchMask` simplified to fire an `onSearch` callback
- `SearchResult` gains "← Earlier trains" / "Later trains →" outlined MUI buttons, only shown when the API returns a ref token, with loading state while navigating

### Local development
- Added `mise run dev:frontend`, `mise run dev:backend`, and `mise run dev:docker` tasks
- Fixed CORS by enabling it in GraphQL Yoga (previously only the Lambda handler injected CORS headers, breaking the local dev HTTP server)
- Fixed profile image loading by setting `crossOrigin="anonymous"` on Avatar components (required for Chromium to expose the S3 presigned URL response)
- Fixed `REACT_APP_API_GATEWAY_ENDPOINT` → `REACT_APP_GRAPHQL_ENDPOINT` in `frontend/.env.development`