### PR TITLE
fix: remove duplicate Access-Control-Allow-Origin header in Lambda response

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,6 @@
-FROM public.ecr.aws/lambda/nodejs:24 as builder
+FROM public.ecr.aws/lambda/nodejs:24 AS builder
 WORKDIR /build
 COPY package*.json ./
-COPY package-lock.json* ./
 RUN npm ci
 COPY . .
 RUN npm run codegen

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -191,7 +191,7 @@ export const handler = async (event: APIGatewayProxyEventV2 | SQSEvent, context:
 
   return {
     statusCode: response.status,
-    headers: { ...CORS_HEADERS, ...responseHeaders },
+    headers: responseHeaders,
     body: responseBody,
   };
 };

--- a/infrastructure/lib/backend.ts
+++ b/infrastructure/lib/backend.ts
@@ -68,7 +68,7 @@ export class Backend extends Construct {
         FRONTEND_URL: `https://${frontendDomainName}`,
         SES_FROM_EMAIL: sesFromEmail,
         NODE_OPTIONS: '--enable-source-maps',
-        DEPLOY_VERSION: 'v11',
+        DEPLOY_VERSION: 'v12',
       },
     });
 


### PR DESCRIPTION
## Problem

Production requests to `https://tpm.wolfgangmoser.eu` were blocked by browsers with:

> CORS header 'Access-Control-Allow-Origin' does not match 'https://tpm.wolfgangmoser.eu, *'

### Root cause

`CORS_HEADERS` used PascalCase keys (`'Access-Control-Allow-Origin'`), while graphql-yoga emits lowercase header keys (`'access-control-allow-origin'`). When merged with:

```ts
headers: { ...CORS_HEADERS, ...responseHeaders }
```

JavaScript's case-sensitive object keys meant both entries survived the spread. API Gateway combined them into a multi-value header (`"*, https://tpm.wolfgangmoser.eu"`), which browsers reject as invalid per the CORS spec.

## Fix

Remove `CORS_HEADERS` from the yoga response return — yoga already produces the correct `access-control-allow-origin` (reflecting the request `Origin`) via its own CORS middleware. `CORS_HEADERS` is still applied for early-exit error paths (OPTIONS preflight and 400 responses) where yoga is not invoked.

```ts
// Before
headers: { ...CORS_HEADERS, ...responseHeaders },

// After
headers: responseHeaders,
```

Also removes the redundant `COPY package-lock.json* ./` line from `backend/Dockerfile` — already covered by the preceding `COPY package*.json ./` glob.

## Testing

Verified in production (`https://tpm.wolfgangmoser.eu`) after deployment — all GraphQL responses now return a single `access-control-allow-origin: https://tpm.wolfgangmoser.eu` header.