### PR TITLE
fix: stale journey handling, SQS reliability, and per-user response cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ request.json
 
 # stats
 stats/
+
+# playwright mcp artifacts
+.playwright-mcp/

--- a/.opencode/skills/local-e2e-testing/SKILL.md
+++ b/.opencode/skills/local-e2e-testing/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: local-e2e-testing
+description: Start backend and frontend dev servers locally, then test the Train Price Monitor website end-to-end using Playwright MCP. Covers server startup, GraphQL schema verification, authenticated UI flows, network request inspection, and cleanup.
+---
+
+## What I do
+
+Walk through the full local E2E test workflow:
+
+1. Ensure Playwright browser is available
+2. Start backend and frontend dev servers in the background
+3. Verify both servers are up via health checks
+4. Optionally verify the GraphQL schema via introspection
+5. Use Playwright MCP to drive the browser (login, search, watchlist, notifications)
+6. Inspect network requests to confirm GraphQL query/mutation shapes
+7. Kill all dev servers when done
+
+---
+
+## Step 1 — Install Playwright browser (once)
+
+```bash
+npx @playwright/mcp install-browser chrome-for-testing
+```
+
+Only needed on first use or after a Playwright version bump. Safe to run again — it's a no-op if already installed.
+
+---
+
+## Step 2 — Start dev servers
+
+Run both in the background, capturing logs:
+
+```bash
+# Terminal / background — backend (sets LOCAL_DEV=1 automatically via mise task)
+cd /path/to/project && mise run //backend:dev > /tmp/backend.log 2>&1 &
+echo "Backend PID: $!"
+
+# Terminal / background — frontend
+cd /path/to/project && mise run //frontend:dev > /tmp/frontend.log 2>&1 &
+echo "Frontend PID: $!"
+```
+
+**Ports:**
+
+- Backend: `http://localhost:4000` (GraphQL at `/graphql`, health at `/health`)
+- Frontend: `http://localhost:3000`
+
+Wait ~8–10 seconds for both to finish cold-starting before running checks.
+
+---
+
+## Step 3 — Health checks
+
+```bash
+sleep 8
+curl -s http://localhost:4000/health          # expect {"status":"ok"}
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/  # expect 200
+```
+
+If the backend fails to start, check `/tmp/backend.log`. Common cause: missing env vars (`TPM_SQS_QUEUE_URL`, `PROFILE_IMAGE_BUCKET_NAME`) — these are set in `backend/.env`.
+
+If the frontend gives a non-200, check `/tmp/frontend.log` for Vite errors.
+
+---
+
+## Step 4 — Optional: verify GraphQL schema via introspection
+
+Use this to confirm schema changes are live without needing a browser login. The backend does **not** require auth for introspection in local dev.
+
+```bash
+# Check all type names
+curl -s -X POST http://localhost:4000/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ __schema { types { name } } }"}' \
+  | python3 -c "import json,sys; [print(t['name']) for t in json.load(sys.stdin)['data']['__schema']['types'] if not t['name'].startswith('__')]"
+
+# Inspect a specific type's fields
+curl -s -X POST http://localhost:4000/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ __type(name: \"Journey\") { fields { name type { name kind ofType { name } } } } }"}' \
+  | python3 -m json.tool
+
+# Inspect mutation args (e.g. verify monitorJourney has no unwanted fields)
+curl -s -X POST http://localhost:4000/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ __type(name: \"Mutation\") { fields { name args { name } } } }"}' \
+  | python3 -m json.tool
+```
+
+---
+
+## Step 5 — Playwright MCP browser testing
+
+### Navigate and take initial snapshot
+
+```
+playwright_browser_navigate { url: "http://localhost:3000" }
+playwright_browser_snapshot {}
+playwright_browser_console_messages { level: "warning" }  # check for errors
+```
+
+### Log in
+
+The app uses real Cognito. Test credentials are stored in the root `.env` file as `TEST_USER_EMAIL` and `TEST_USER_PASSWORD`. Read them before starting the test session:
+
+```bash
+source .env
+echo "Using test user: $TEST_USER_EMAIL"
+```
+
+The login dialog is triggered by clicking the Login button on the home page:
+
+```
+playwright_browser_run_code_unsafe {
+  code: `async (page) => {
+    await page.getByRole('button', { name: 'Login' }).click();
+    await page.waitForTimeout(500);
+    await page.getByRole('textbox', { name: 'Email' }).fill('$TEST_USER_EMAIL');
+    await page.getByRole('textbox', { name: 'Password' }).fill('$TEST_USER_PASSWORD');
+    await page.getByRole('button', { name: 'Login' }).click();
+    await page.waitForTimeout(3000);
+  }`
+}
+playwright_browser_take_screenshot { filename: "after-login.png", type: "png" }
+```
+
+Credentials are sourced from `.env`: `TEST_USER_EMAIL` / `TEST_USER_PASSWORD`.
+
+After login, the header shows Search / Journey Watchlist / notification bell / profile picture. If it still shows Sign up / Login, check for auth errors in the console.
+
+### Search for journeys
+
+```
+playwright_browser_run_code_unsafe {
+  code: `async (page) => {
+    await page.getByRole('link', { name: 'Search' }).click();
+    await page.waitForTimeout(500);
+    const inputs = page.locator('input[role="combobox"]');
+    await inputs.first().fill('München');
+    await page.waitForTimeout(1500);
+    await page.getByRole('option', { name: 'München Hbf' }).first().click();
+    await inputs.nth(1).fill('Berlin');
+    await page.waitForTimeout(1500);
+    await page.getByRole('option', { name: 'Berlin Hbf' }).first().click();
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    await page.locator('input[type="date"]').fill(tomorrow.toISOString().split('T')[0]);
+    await page.locator('input[type="time"]').fill('10:00');
+    await page.locator('button[type="submit"]').click();
+    await page.waitForTimeout(8000);
+  }`
+}
+playwright_browser_take_screenshot { filename: "search-results.png", type: "png" }
+```
+
+Results should show a table with Departure Time / Arrival Time / Duration / Means of Transport / Price / WATCH buttons.
+
+### Add a journey to the watchlist
+
+The WATCH buttons are **inside a `<table>`**. Do NOT use `button:has-text("Watch")` — that also matches the "Journey Watchlist" nav button. Use:
+
+```
+playwright_browser_run_code_unsafe {
+  code: `async (page) => {
+    await page.locator('table button').first().click();
+    await page.waitForTimeout(500);
+  }`
+}
+```
+
+A "Set Limit Price" dialog opens showing the current price. Enter a limit price **above** the current price:
+
+```
+playwright_browser_run_code_unsafe {
+  code: `async (page) => {
+    await page.getByRole('spinbutton', { name: 'Limit Price' }).fill('200');
+    await page.getByRole('button', { name: 'Confirm' }).click();
+    await page.waitForTimeout(4000);
+  }`
+}
+```
+
+### Inspect the GraphQL mutation in network requests
+
+After clicking Confirm, use `playwright_browser_network_requests` to find the POST to `/graphql` and verify its body:
+
+```
+playwright_browser_network_requests { filter: "/graphql", static: false }
+# Note the index of the POST request, then:
+playwright_browser_network_request { index: <N>, part: "request-body" }
+playwright_browser_network_request { index: <N>, part: "response-body" }
+```
+
+The mutation body should contain `fromId`/`toId` (not `from`/`to`). The response should contain a `JourneyMonitor` with an `id`.
+
+### Verify the Journey Watchlist
+
+```
+playwright_browser_run_code_unsafe {
+  code: `async (page) => {
+    await page.getByRole('link', { name: 'Journey Watchlist' }).click();
+    await page.waitForTimeout(3000);
+  }`
+}
+playwright_browser_take_screenshot { filename: "watchlist.png", type: "png" }
+```
+
+The accordion header should show human-readable station names (e.g. "München Hbf to Berlin Hbf"), a limit price, and a current price. Expand the accordion to verify departure / arrival / means of transport.
+
+### Check notifications panel
+
+Click the bell icon in the header to open the notifications popover. With a fresh account this will be empty, but the panel should open without errors.
+
+### Clean up test data
+
+Delete any journey monitors added during testing:
+
+```
+playwright_browser_run_code_unsafe {
+  code: `async (page) => {
+    await page.locator('button[aria-label="delete"]').click();
+    await page.waitForTimeout(1000);
+  }`
+}
+```
+
+---
+
+## Step 6 — Console error check
+
+At any point, check for unexpected JS errors:
+
+```
+playwright_browser_console_messages { level: "error" }
+```
+
+Known pre-existing non-critical warning (not introduced by us):
+
+> "Encountered two children with the same key `Berlin Hbf`" — duplicate React key in the station autocomplete component.
+
+Any other errors should be investigated.
+
+---
+
+## Step 7 — Kill dev servers
+
+```bash
+# Kill by finding the processes
+pkill -9 -f "ts-node-dev" 2>/dev/null
+pkill -9 -f "vite" 2>/dev/null
+
+# Or kill by PID if you saved them
+kill -9 <BACKEND_PID> <FRONTEND_PID>
+
+# Verify ports are free
+ss -tlnp | grep -E ':3000|:4000' || echo "ports clear"
+```
+
+---
+
+## Environment requirements
+
+- `backend/.env` must exist with `TPM_SQS_QUEUE_URL`, `PROFILE_IMAGE_BUCKET_NAME`, `AWS_PROFILE`
+- `frontend/.env` must exist with Cognito pool IDs and `REACT_APP_AWS_REGION`
+- `frontend/.env.development` must set `REACT_APP_GRAPHQL_ENDPOINT=http://localhost:4000/`
+- AWS credentials must be valid for the profile in `backend/.env` (DynamoDB reads/writes happen against live AWS)
+- Root `.env` contains `TEST_USER_EMAIL` and `TEST_USER_PASSWORD` — real Cognito credentials for the test account; `source .env` before starting
+
+---
+
+## Known gotchas
+
+- **`button:has-text("Watch")` matches the nav button too** — always use `table button` or `button[type="submit"]` to target table-row buttons
+- **`getByLabel` can match a dialog container and its input** — use `getByRole('spinbutton', { name: '...' })` for number inputs
+- **Backend logs no incoming requests by default** — use `playwright_browser_network_requests` to verify GraphQL traffic instead
+- **Cold start after deploy** — the first Lambda invocation post-deploy takes ~15s; not relevant for local testing but worth noting
+- **`mise run //frontend:dev` navigating directly to `/search` redirects to `/`** — always use the nav link after login, not `playwright_browser_navigate` to a protected route

--- a/.opencode/skills/local-e2e-testing/SKILL.md
+++ b/.opencode/skills/local-e2e-testing/SKILL.md
@@ -109,23 +109,22 @@ source .env
 echo "Using test user: $TEST_USER_EMAIL"
 ```
 
-The login dialog is triggered by clicking the Login button on the home page:
+The login dialog is triggered by clicking the Login button on the home page. Credentials are read
+from `process.env` — they are injected at startup via the root `.env` file (see above):
 
 ```
 playwright_browser_run_code_unsafe {
   code: `async (page) => {
     await page.getByRole('button', { name: 'Login' }).click();
     await page.waitForTimeout(500);
-    await page.getByRole('textbox', { name: 'Email' }).fill('$TEST_USER_EMAIL');
-    await page.getByRole('textbox', { name: 'Password' }).fill('$TEST_USER_PASSWORD');
+    await page.getByRole('textbox', { name: 'Email' }).fill(process.env.TEST_USER_EMAIL);
+    await page.getByRole('textbox', { name: 'Password' }).fill(process.env.TEST_USER_PASSWORD);
     await page.getByRole('button', { name: 'Login' }).click();
     await page.waitForTimeout(3000);
   }`
 }
 playwright_browser_take_screenshot { filename: "after-login.png", type: "png" }
 ```
-
-Credentials are sourced from `.env`: `TEST_USER_EMAIL` / `TEST_USER_PASSWORD`.
 
 After login, the header shows Search / Journey Watchlist / notification bell / profile picture. If it still shows Sign up / Login, check for auth errors in the console.
 

--- a/backend/src/codegen.yml
+++ b/backend/src/codegen.yml
@@ -11,9 +11,14 @@ generates:
         File: File
   src/schema/generated/resolvers.generated.ts:
     plugins:
+      - add:
+          content: 'import * as Types from "./typeDefs.generated";'
       - 'typescript-resolvers'
     config:
       scalars:
         File: File
-      contextType: ../context#GraphQLContext
-      import: './typeDefs.generated'
+      contextType: ../../context#GraphQLContext
+      namespacedImportName: Types
+      mappers:
+        User: ./typeDefs.generated#User
+        Notification: ./typeDefs.generated#Notification

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -25,13 +25,25 @@ const YOGA_CORS_CONFIG = {
   allowedHeaders: ['Content-Type', 'Authorization', 'X-Api-Key'],
 };
 
+function extractUserId(request: Request): string | null {
+  const auth = request.headers.get('authorization');
+  if (!auth) return null;
+  const token = auth.startsWith('Bearer ') ? auth.slice(7) : auth;
+  try {
+    const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString()) as Record<string, unknown>;
+    return typeof payload['sub'] === 'string' ? payload['sub'] : null;
+  } catch {
+    return null;
+  }
+}
+
 const yoga = createYoga({
   schema,
   context: ({ request }) => createContext(cache, { request }),
   fetchAPI: { fetch: globalThis.fetch },
   cors: YOGA_CORS_CONFIG,
   plugins: [
-    useResponseCache({ session: () => null, cache }),
+    useResponseCache({ session: (request) => extractUserId(request), cache }),
     useErrorHandler(({ errors, phase }) => {
       for (const error of errors) {
         if (error instanceof Error) {

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -136,11 +136,11 @@ export const handler = async (event: APIGatewayProxyEventV2 | SQSEvent, context:
       contextValue: graphqlContext,
     });
     if (result.errors && result.errors.length > 0) {
-      logger.error('SQS message processing failed', {
+      logger.error('SQS message processing failed, dropping message', {
         errorCount: result.errors.length,
         errors: result.errors.map((error) => ({ message: error.message, path: error.path })),
       });
-      throw new Error('SQS GraphQL execution failed');
+      return { statusCode: 200, body: '' }; // Don't throw - message will be removed from queue
     }
     logger.info('SQS message processed', { hasErrors: false });
     return { statusCode: 200, body: '' };

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -148,11 +148,15 @@ export const handler = async (event: APIGatewayProxyEventV2 | SQSEvent, context:
       contextValue: graphqlContext,
     });
     if (result.errors && result.errors.length > 0) {
-      logger.error('SQS message processing failed, dropping message', {
+      const messages = result.errors.map((e) => e.message).join('; ');
+      logger.error('SQS message processing failed', {
         errorCount: result.errors.length,
         errors: result.errors.map((error) => ({ message: error.message, path: error.path })),
       });
-      return { statusCode: 200, body: '' }; // Don't throw - message will be removed from queue
+      // Throw so SQS retries the message (up to maxReceiveCount) before routing to the DLQ.
+      // Expected outcomes like stale journeys are handled inside the resolver without errors,
+      // so anything reaching here is a genuine transient failure worth retrying.
+      throw new Error(`GraphQL execution error(s): ${messages}`);
     }
     logger.info('SQS message processed', { hasErrors: false });
     return { statusCode: 200, body: '' };

--- a/backend/src/managers/DbHafasManager.ts
+++ b/backend/src/managers/DbHafasManager.ts
@@ -148,4 +148,14 @@ export class DbHafasManager {
       .sort((a, b) => b.weight - a.weight)
       .slice(0, results) as unknown as readonly Station[];
   }
+
+  /**
+   * Looks up a station by its HAFAS station ID from the in-memory station cache.
+   * @param id - The HAFAS station ID to look up.
+   * @returns A promise that resolves to the matching station, or undefined if not found.
+   */
+  async getStationById(id: string): Promise<SimpleStation | undefined> {
+    const stations = await getStationCache();
+    return stations.find((s) => s.id === id);
+  }
 }

--- a/backend/src/managers/DbHafasManager.ts
+++ b/backend/src/managers/DbHafasManager.ts
@@ -83,15 +83,9 @@ export class DbHafasManager {
       throw new Error('refreshToken is undefined');
     }
 
-    let result: JourneyWithRealtimeData | undefined;
-    try {
-      result = await this.client.refreshJourney!(refreshToken, {
-        tickets: true,
-      });
-    } catch {
-      Logger.error('Error refreshing journey');
-      return undefined;
-    }
+    const result: JourneyWithRealtimeData | undefined = await this.client.refreshJourney!(refreshToken, {
+      tickets: true,
+    });
 
     if (!result) {
       return undefined;

--- a/backend/src/model/trainPriceMonitor.ts
+++ b/backend/src/model/trainPriceMonitor.ts
@@ -65,6 +65,9 @@ export const Journey = new Entity({
     limitPrice: number().required(),
     refreshToken: string().required(),
     expires: string().required(),
+    fromId: string().required(),
+    toId: string().required(),
+    departure: string().required(),
   }),
   computeKey: ({ userId, id }) => ({
     pk: `USER#${userId}`,

--- a/backend/src/resolvers/journey.ts
+++ b/backend/src/resolvers/journey.ts
@@ -219,7 +219,7 @@ export const updateJourneyMonitor: NonNullable<MutationResolvers['updateJourneyM
   // Check if notification already exists (PRICE_ALERT or JOURNEY_STALE for this journey)
   const existingNotifications = await context.entities.TrainPriceMonitorTable.build(QueryCommand)
     .entities(context.entities.Notification)
-    .query({ partition: `USER#${args.userId}` })
+    .query({ partition: `USER#${args.userId}`, range: { beginsWith: 'NOTIFICATION#' } })
     .send();
 
   const notificationsArray = existingNotifications?.Items ?? [];
@@ -243,51 +243,58 @@ export const updateJourneyMonitor: NonNullable<MutationResolvers['updateJourneyM
   try {
     journey = await context.dbHafas.requeryJourney(dbJourney.Item.refreshToken);
   } catch (error) {
-    Logger.error('Error requerying journey, treating as stale', {
+    Logger.error('Error requerying journey', {
       journeyId: args.journeyId,
       error: error instanceof Error ? error.message : error,
     });
+    throw error;
   }
 
   if (!journey) {
     // Token is stale — attempt recovery using stored station IDs and departure
     Logger.warn('Refresh token stale, attempting recovery', { journeyId: args.journeyId });
 
-    const fromStationId = dbJourney.Item.fromId;
-    const toStationId = dbJourney.Item.toId;
-    const departure = new Date(dbJourney.Item.departure);
+    const fromStationId = dbJourney.Item.fromId as string | undefined;
+    const toStationId = dbJourney.Item.toId as string | undefined;
+    const storedDeparture = dbJourney.Item.departure as string | undefined;
 
-    try {
-      const result = await context.dbHafas.queryJourneys(fromStationId, toStationId, departure, { results: 5 });
+    if (!fromStationId || !toStationId || !storedDeparture) {
+      Logger.warn('Missing station IDs or departure for recovery, skipping', { journeyId: args.journeyId });
+    } else {
+      const departure = new Date(storedDeparture);
 
-      // Filter by matching origin/destination station IDs, then pick the candidate whose
-      // planned departure is closest to the stored departure time to avoid reattaching to a
-      // different service on the same route.
-      const candidates = result.journeys?.filter(
-        (j) => j.legs[0]?.origin?.id === fromStationId && j.legs[j.legs.length - 1]?.destination?.id === toStationId
-      );
-      const matchingJourney = candidates?.reduce<(typeof candidates)[number] | undefined>((best, j) => {
-        const jDep = new Date(j.legs[0]?.plannedDeparture ?? j.legs[0]?.departure ?? 0).getTime();
-        const jDiff = Math.abs(jDep - departure.getTime());
-        if (!best) return j;
-        const bestDep = new Date(best.legs[0]?.plannedDeparture ?? best.legs[0]?.departure ?? 0).getTime();
-        const bestDiff = Math.abs(bestDep - departure.getTime());
-        return jDiff < bestDiff ? j : best;
-      }, undefined);
+      try {
+        const result = await context.dbHafas.queryJourneys(fromStationId, toStationId, departure, { results: 5 });
 
-      if (matchingJourney) {
-        // Update token in DB
-        await context.entities.Journey.build(UpdateItemCommand)
-          .item({ userId: args.userId, id: args.journeyId, refreshToken: matchingJourney.refreshToken! })
-          .send();
-        journey = matchingJourney;
-        Logger.info('Successfully recovered journey with new token', { journeyId: args.journeyId });
+        // Filter by matching origin/destination station IDs, then pick the candidate whose
+        // planned departure is closest to the stored departure time to avoid reattaching to a
+        // different service on the same route.
+        const candidates = result.journeys?.filter(
+          (j) => j.legs[0]?.origin?.id === fromStationId && j.legs[j.legs.length - 1]?.destination?.id === toStationId
+        );
+        const matchingJourney = candidates?.reduce<(typeof candidates)[number] | undefined>((best, j) => {
+          const jDep = new Date(j.legs[0]?.plannedDeparture ?? j.legs[0]?.departure ?? 0).getTime();
+          const jDiff = Math.abs(jDep - departure.getTime());
+          if (!best) return j;
+          const bestDep = new Date(best.legs[0]?.plannedDeparture ?? best.legs[0]?.departure ?? 0).getTime();
+          const bestDiff = Math.abs(bestDep - departure.getTime());
+          return jDiff < bestDiff ? j : best;
+        }, undefined);
+
+        if (matchingJourney) {
+          // Update token in DB
+          await context.entities.Journey.build(UpdateItemCommand)
+            .item({ userId: args.userId, id: args.journeyId, refreshToken: matchingJourney.refreshToken! })
+            .send();
+          journey = matchingJourney;
+          Logger.info('Successfully recovered journey with new token', { journeyId: args.journeyId });
+        }
+      } catch (recoveryError) {
+        Logger.error('Journey recovery failed', {
+          journeyId: args.journeyId,
+          error: recoveryError instanceof Error ? recoveryError.message : recoveryError,
+        });
       }
-    } catch (recoveryError) {
-      Logger.error('Journey recovery failed', {
-        journeyId: args.journeyId,
-        error: recoveryError instanceof Error ? recoveryError.message : recoveryError,
-      });
     }
   }
 
@@ -369,7 +376,7 @@ export const updateJourneyMonitor: NonNullable<MutationResolvers['updateJourneyM
 async function deletePriceAlertNotificationsForJourney(context: GraphQLContext, userId: string, journeyId: string) {
   const { Items: priceAlertNotifications } = await context.entities.TrainPriceMonitorTable.build(QueryCommand)
     .entities(context.entities.Notification)
-    .query({ partition: `USER#${userId}` })
+    .query({ partition: `USER#${userId}`, range: { beginsWith: 'NOTIFICATION#' } })
     .options({
       filters: {
         Notification: { attr: 'type', eq: NOTIFICATION_TYPES.PRICE_ALERT.name },
@@ -448,7 +455,7 @@ export const deleteJourneyMonitor: NonNullable<MutationResolvers['deleteJourneyM
   // Delete all notifications for the journey (with data containing the journey ID)
   const { Items: notifications } = await context.entities.TrainPriceMonitorTable.build(QueryCommand)
     .entities(context.entities.Notification)
-    .query({ partition: `USER#${userId}` })
+    .query({ partition: `USER#${userId}`, range: { beginsWith: 'NOTIFICATION#' } })
     .send();
 
   const journeyNotifications = notifications?.filter((item: { data?: string }) => {

--- a/backend/src/resolvers/journey.ts
+++ b/backend/src/resolvers/journey.ts
@@ -259,9 +259,21 @@ export const updateJourneyMonitor: NonNullable<MutationResolvers['updateJourneyM
 
     try {
       const result = await context.dbHafas.queryJourneys(fromStationId, toStationId, departure, { results: 5 });
-      const matchingJourney = result.journeys?.find(
+
+      // Filter by matching origin/destination station IDs, then pick the candidate whose
+      // planned departure is closest to the stored departure time to avoid reattaching to a
+      // different service on the same route.
+      const candidates = result.journeys?.filter(
         (j) => j.legs[0]?.origin?.id === fromStationId && j.legs[j.legs.length - 1]?.destination?.id === toStationId
       );
+      const matchingJourney = candidates?.reduce<(typeof candidates)[number] | undefined>((best, j) => {
+        const jDep = new Date(j.legs[0]?.plannedDeparture ?? j.legs[0]?.departure ?? 0).getTime();
+        const jDiff = Math.abs(jDep - departure.getTime());
+        if (!best) return j;
+        const bestDep = new Date(best.legs[0]?.plannedDeparture ?? best.legs[0]?.departure ?? 0).getTime();
+        const bestDiff = Math.abs(bestDep - departure.getTime());
+        return jDiff < bestDiff ? j : best;
+      }, undefined);
 
       if (matchingJourney) {
         // Update token in DB

--- a/backend/src/resolvers/journey.ts
+++ b/backend/src/resolvers/journey.ts
@@ -3,6 +3,7 @@ import { GraphQLContext } from '../context';
 import {
   GetItemCommand,
   PutItemCommand,
+  UpdateItemCommand,
   DeleteItemCommand,
   ScanCommand,
   QueryCommand,
@@ -42,8 +43,8 @@ export const journeysQuery: NonNullable<QueryResolvers['journeys']> = async (
     .filter((journey) => !journey.legs.some((leg) => leg.cancelled))
     .map((journey) => {
       return {
-        from: args.from,
-        to: args.to,
+        fromId: journey.legs[0].origin!.id!,
+        toId: journey.legs[journey.legs.length - 1].destination!.id!,
         departure: new Date(journey.legs[0].plannedDeparture!),
         arrival: new Date(journey.legs[journey.legs.length - 1].plannedArrival!),
         refreshToken: journey.refreshToken!,
@@ -88,6 +89,9 @@ export const monitorJourney: NonNullable<MutationResolvers['monitorJourney']> = 
       limitPrice: args.limitPrice,
       refreshToken: args.refreshToken,
       expires: args.expires,
+      fromId: args.fromId,
+      toId: args.toId,
+      departure: args.departure,
     })
     .send();
 
@@ -126,10 +130,21 @@ export const updateJourneyMonitors: NonNullable<MutationResolvers['updateJourney
 
   if (allJourneys) {
     for (const journey of allJourneys) {
-      const userId = journey.userId;
-      const id = journey.id;
-      // Schedule message for each journey
-      await context.sqs.sendUpdateJourneyMessage(userId, id);
+      // Skip expired journeys
+      if (new Date(journey.expires) < new Date()) {
+        Logger.info('Skipping expired journey in update scan', { journeyId: journey.id });
+        continue;
+      }
+
+      try {
+        await context.sqs.sendUpdateJourneyMessage(journey.userId, journey.id);
+      } catch (error) {
+        Logger.error('Failed to send update message for journey', {
+          journeyId: journey.id,
+          userId: journey.userId,
+          error: error instanceof Error ? error.message : error,
+        });
+      }
     }
   }
 
@@ -201,21 +216,16 @@ export const updateJourneyMonitor: NonNullable<MutationResolvers['updateJourneyM
     return journeyMonitor;
   }
 
-  // Check if notification already exists
+  // Check if notification already exists (PRICE_ALERT or JOURNEY_STALE for this journey)
   const existingNotifications = await context.entities.TrainPriceMonitorTable.build(QueryCommand)
     .entities(context.entities.Notification)
     .query({ partition: `USER#${args.userId}` })
-    .options({
-      filters: {
-        Notification: { attr: 'type', eq: NOTIFICATION_TYPES.PRICE_ALERT.name },
-      },
-    })
     .send();
 
   const notificationsArray = existingNotifications?.Items ?? [];
   if (
-    notificationsArray.some((item: { data?: string }) => {
-      if (!item.data) return false;
+    notificationsArray.some((item: { data?: string; type?: string }) => {
+      if (item.type !== NOTIFICATION_TYPES.PRICE_ALERT.name || !item.data) return false;
       try {
         return JSON.parse(item.data).journeyId === args.journeyId;
       } catch {
@@ -223,14 +233,92 @@ export const updateJourneyMonitor: NonNullable<MutationResolvers['updateJourneyM
       }
     })
   ) {
-    Logger.info(`Notification already exists for journey`);
+    Logger.info(`PRICE_ALERT notification already exists for journey`);
     return journeyMonitor;
   }
 
   // Get new price for journey and compare to limit price
-  const journey = await context.dbHafas.requeryJourney(dbJourney.Item.refreshToken);
+  let journey: HafasJourney | undefined;
+
+  try {
+    journey = await context.dbHafas.requeryJourney(dbJourney.Item.refreshToken);
+  } catch (error) {
+    Logger.error('Error requerying journey, treating as stale', {
+      journeyId: args.journeyId,
+      error: error instanceof Error ? error.message : error,
+    });
+  }
+
   if (!journey) {
-    throw new Error('Could not requery journey');
+    // Token is stale — attempt recovery using stored station IDs and departure
+    Logger.warn('Refresh token stale, attempting recovery', { journeyId: args.journeyId });
+
+    const fromStationId = dbJourney.Item.fromId;
+    const toStationId = dbJourney.Item.toId;
+    const departure = new Date(dbJourney.Item.departure);
+
+    try {
+      const result = await context.dbHafas.queryJourneys(fromStationId, toStationId, departure, { results: 5 });
+      const matchingJourney = result.journeys?.find(
+        (j) => j.legs[0]?.origin?.id === fromStationId && j.legs[j.legs.length - 1]?.destination?.id === toStationId
+      );
+
+      if (matchingJourney) {
+        // Update token in DB
+        await context.entities.Journey.build(UpdateItemCommand)
+          .item({ userId: args.userId, id: args.journeyId, refreshToken: matchingJourney.refreshToken! })
+          .send();
+        journey = matchingJourney;
+        Logger.info('Successfully recovered journey with new token', { journeyId: args.journeyId });
+      }
+    } catch (recoveryError) {
+      Logger.error('Journey recovery failed', {
+        journeyId: args.journeyId,
+        error: recoveryError instanceof Error ? recoveryError.message : recoveryError,
+      });
+    }
+  }
+
+  if (!journey) {
+    // Recovery failed — journey may be cancelled or rescheduled. Notify user.
+    Logger.warn('Journey recovery failed completely, creating notification', { journeyId: args.journeyId });
+
+    // Check if a JOURNEY_STALE notification already exists for this journey
+    const hasExistingStaleNotification = notificationsArray.some((item: { data?: string; type?: string }) => {
+      if (item.type !== NOTIFICATION_TYPES.JOURNEY_STALE.name || !item.data) return false;
+      try {
+        return JSON.parse(item.data).journeyId === args.journeyId;
+      } catch {
+        return false;
+      }
+    });
+
+    if (hasExistingStaleNotification) {
+      Logger.info('JOURNEY_STALE notification already exists for journey, skipping');
+      return journeyMonitor;
+    }
+
+    const notificationId = uuidv4();
+    await context.entities.Notification.build(PutItemCommand)
+      .item({
+        id: notificationId,
+        userId: args.userId,
+        type: NOTIFICATION_TYPES.JOURNEY_STALE.name,
+        read: false,
+        sent: false,
+        timestamp: new Date().toISOString(),
+        data: JSON.stringify({
+          journeyId: args.journeyId,
+          fromId: dbJourney.Item.fromId,
+          toId: dbJourney.Item.toId,
+        }),
+      })
+      .send();
+    context.cache.invalidate([{ typename: 'Notification' }]);
+
+    await sendNotificationEmailIfEnabled(context, args.userId, notificationId);
+
+    return journeyMonitor; // Return gracefully, don't throw
   }
   const newPrice = journey.price?.amount;
 

--- a/backend/src/resolvers/notification.ts
+++ b/backend/src/resolvers/notification.ts
@@ -2,7 +2,11 @@ import { GraphQLContext } from '../context';
 import { GetItemCommand, UpdateItemCommand } from '../model/trainPriceMonitor';
 import { MutationResolvers, NotificationResolvers } from '../schema/generated/resolvers.generated';
 import Logger from '../lib/logger';
-import { JourneyExpiryNotification, PriceAlertNotification } from '../schema/generated/typeDefs.generated';
+import {
+  JourneyExpiryNotification,
+  JourneyStaleNotification,
+  PriceAlertNotification,
+} from '../schema/generated/typeDefs.generated';
 import { NOTIFICATION_TYPES } from './notificationTypes';
 
 export const notificationResolvers: NotificationResolvers = {
@@ -13,6 +17,9 @@ export const notificationResolvers: NotificationResolvers = {
     if (data.type === NOTIFICATION_TYPES.JOURNEY_EXPIRED.name) {
       return 'JourneyExpiryNotification';
     }
+    if (data.type === NOTIFICATION_TYPES.JOURNEY_STALE.name) {
+      return 'JourneyStaleNotification';
+    }
     return null;
   },
 };
@@ -21,7 +28,7 @@ export const markNotificationAsRead: NonNullable<MutationResolvers['markNotifica
   _parent,
   args,
   context: GraphQLContext
-): Promise<JourneyExpiryNotification | PriceAlertNotification> => {
+): Promise<JourneyExpiryNotification | JourneyStaleNotification | PriceAlertNotification> => {
   // Add user and notification ID to persistent log attributes
   Logger.addPersistentLogAttributes({ userId: args.userId, notificationId: args.notificationId });
 
@@ -38,7 +45,7 @@ export const markNotificationAsRead: NonNullable<MutationResolvers['markNotifica
   // Check if the notification is already read
   if (dbNotification.read) {
     Logger.info(`Notification is already read`);
-    return dbNotification as unknown as JourneyExpiryNotification | PriceAlertNotification;
+    return dbNotification as unknown as JourneyExpiryNotification | JourneyStaleNotification | PriceAlertNotification;
   }
 
   // Update the notification in the database
@@ -50,14 +57,14 @@ export const markNotificationAsRead: NonNullable<MutationResolvers['markNotifica
   context.cache.invalidate([{ typename: 'Notification' }]);
   Logger.info(`Marked notification as read`);
 
-  return notification as unknown as JourneyExpiryNotification | PriceAlertNotification;
+  return notification as unknown as JourneyExpiryNotification | JourneyStaleNotification | PriceAlertNotification;
 };
 
 export const sendEmailNotification: NonNullable<MutationResolvers['sendEmailNotification']> = async (
   _parent,
   { userId, notificationId },
   context: GraphQLContext
-): Promise<JourneyExpiryNotification | PriceAlertNotification> => {
+): Promise<JourneyExpiryNotification | JourneyStaleNotification | PriceAlertNotification> => {
   // Add user and notification ID to persistent log attributes
   Logger.addPersistentLogAttributes({ userId, notificationId });
 
@@ -74,7 +81,7 @@ export const sendEmailNotification: NonNullable<MutationResolvers['sendEmailNoti
   // Check if the notification is already sent
   if (dbNotification.sent) {
     Logger.info(`Notification is already sent`);
-    return dbNotification as unknown as JourneyExpiryNotification | PriceAlertNotification;
+    return dbNotification as unknown as JourneyExpiryNotification | JourneyStaleNotification | PriceAlertNotification;
   }
 
   // Get the user from the database
@@ -104,5 +111,5 @@ export const sendEmailNotification: NonNullable<MutationResolvers['sendEmailNoti
   context.cache.invalidate([{ typename: 'Notification' }]);
   Logger.info(`Marked notification as sent`);
 
-  return notification as unknown as JourneyExpiryNotification | PriceAlertNotification;
+  return notification as unknown as JourneyExpiryNotification | JourneyStaleNotification | PriceAlertNotification;
 };

--- a/backend/src/resolvers/notificationTypes.ts
+++ b/backend/src/resolvers/notificationTypes.ts
@@ -26,19 +26,19 @@ export const NOTIFICATION_TYPES: { [key: string]: NotificationType } = {
       return { journeyMonitor: getJourneyMonitorByJourneyId(context, userId, data['journeyId'] as string) };
     },
     formatEmail: async (context, user, data) => {
-      const { id, journey, limitPrice } = await getJourneyMonitorByJourneyId(
+      const { id, from, to, journey, limitPrice } = await getJourneyMonitorByJourneyId(
         context,
         user.id,
         data['journeyId'] as string
       );
-      if (!journey) {
-        throw new Error('Could not retrieve journey');
+      if (!from || !to) {
+        throw new Error('Could not retrieve journey station names');
       }
-      const subject = `Price alert for your journey from ${journey.from} to ${journey.to}`;
+      const subject = `Price alert for your journey from ${from} to ${to}`;
       const htmlBody = `
         <p>Hi ${user.givenName},</p>
-        <p>The price for your journey from <b>${journey.from}</b> to <b>${journey.to}</b> has changed.</p>
-        <p>It is now <b>€${journey.price?.toFixed(2)}</b> (your limit price was <b>€${limitPrice.toFixed(2)}</b>).</p>
+        <p>The price for your journey from <b>${from}</b> to <b>${to}</b> has changed.</p>
+        <p>It is now <b>€${journey?.price?.toFixed(2)}</b> (your limit price was <b>€${limitPrice.toFixed(2)}</b>).</p>
         <p>Check it out here: <a href="${process.env.FRONTEND_URL || 'http://localhost:3000'}/journeys#${id}">${
           process.env.FRONTEND_URL || 'http://localhost:3000'
         }/journeys#${id}</a></p>
@@ -49,20 +49,14 @@ export const NOTIFICATION_TYPES: { [key: string]: NotificationType } = {
   },
   JOURNEY_EXPIRED: {
     name: 'JOURNEY_EXPIRED',
-    mapAdditionalData: async (context, userId, data) => {
+    mapAdditionalData: async (context, _userId, data) => {
       const journey = await context.dbHafas.requeryJourney(data['refreshToken'] as string);
       if (!journey) {
         throw new Error('Could not requery journey');
       }
       return {
-        journey: {
-          refreshToken: journey.refreshToken!,
-          from: journey.legs[0].origin!.name!,
-          to: journey.legs[journey.legs.length - 1].destination!.name!,
-          departure: new Date(journey.legs[0].plannedDeparture!),
-          arrival: new Date(journey.legs[journey.legs.length - 1].plannedArrival!),
-          price: journey.price?.amount,
-        },
+        from: journey.legs[0].origin!.name!,
+        to: journey.legs[journey.legs.length - 1].destination!.name!,
       };
     },
     formatEmail: async (context, user, data) => {
@@ -79,6 +73,40 @@ export const NOTIFICATION_TYPES: { [key: string]: NotificationType } = {
         Visit <a href="${process.env.FRONTEND_URL || 'http://localhost:3000'}/">${
           process.env.FRONTEND_URL || 'http://localhost:3000'
         }/</a> to monitor a new journey.</p>
+        <p>Best regards,<br/>Train Price Monitor</p>
+      `;
+      return { to: user.email, subject, htmlBody };
+    },
+  },
+  JOURNEY_STALE: {
+    name: 'JOURNEY_STALE',
+    mapAdditionalData: async (context, _userId, data) => {
+      const fromId = data['fromId'] as string;
+      const toId = data['toId'] as string;
+      const fromStation = await context.dbHafas.getStationById(fromId);
+      const toStation = await context.dbHafas.getStationById(toId);
+      return {
+        journeyId: data['journeyId'] as string,
+        from: fromStation?.name ?? fromId,
+        to: toStation?.name ?? toId,
+      };
+    },
+    formatEmail: async (context, user, data) => {
+      const fromId = data['fromId'] as string;
+      const toId = data['toId'] as string;
+      const fromStation = await context.dbHafas.getStationById(fromId);
+      const toStation = await context.dbHafas.getStationById(toId);
+      const from = fromStation?.name ?? fromId;
+      const to = toStation?.name ?? toId;
+      const journeyId = data['journeyId'] as string;
+      const subject = `Your train from ${from} to ${to} can no longer be tracked`;
+      const htmlBody = `
+        <p>Hi ${user.givenName},</p>
+        <p>The train from <b>${from}</b> to <b>${to}</b> that you're monitoring can no longer be tracked.</p>
+        <p>This typically happens when the train has been <b>cancelled</b> or its <b>schedule has changed</b>.</p>
+        <p>You may want to <a href="${
+          process.env.FRONTEND_URL || 'http://localhost:3000'
+        }/journeys#${journeyId}">delete this journey monitor</a> and set one up again once updated schedules are available.</p>
         <p>Best regards,<br/>Train Price Monitor</p>
       `;
       return { to: user.email, subject, htmlBody };

--- a/backend/src/resolvers/user.ts
+++ b/backend/src/resolvers/user.ts
@@ -15,6 +15,7 @@ import {
   PresignedUrl,
   JourneyMonitor,
   JourneyExpiryNotification,
+  JourneyStaleNotification,
   PriceAlertNotification,
   InputMaybe,
 } from '../schema/generated/typeDefs.generated';
@@ -35,7 +36,7 @@ export const userResolvers: UserResolvers = {
     parent,
     args,
     context: GraphQLContext
-  ): Promise<(JourneyExpiryNotification | PriceAlertNotification)[]> => {
+  ): Promise<(JourneyExpiryNotification | JourneyStaleNotification | PriceAlertNotification)[]> => {
     const { Items: dbNotifications } = await context.entities.TrainPriceMonitorTable.build(QueryCommand)
       .entities(context.entities.Notification)
       .query({ partition: `USER#${parent.id}`, range: { beginsWith: 'NOTIFICATION#' } })
@@ -79,7 +80,7 @@ export const userResolvers: UserResolvers = {
             read: dbNotification.read,
             sent: dbNotification.sent,
             ...additionalData,
-          } as JourneyExpiryNotification | PriceAlertNotification;
+          } as JourneyExpiryNotification | JourneyStaleNotification | PriceAlertNotification;
         }
       )
     );
@@ -338,12 +339,12 @@ export async function getJourneyMonitor(
     userId: dbJourney.userId,
     limitPrice: dbJourney.limitPrice,
     expires: dbJourney.expires,
+    from: journey?.legs[0].origin?.name ?? undefined,
+    to: journey ? journey.legs[journey.legs.length - 1].destination?.name ?? undefined : undefined,
     journey: !journey
       ? undefined
       : {
           refreshToken: journey.refreshToken!,
-          from: journey.legs[0].origin!.name!,
-          to: journey.legs[journey.legs.length - 1].destination!.name!,
           departure: new Date(journey.legs[0].plannedDeparture!),
           arrival: new Date(journey.legs[journey.legs.length - 1].plannedArrival!),
           means: getMeans(journey),

--- a/backend/src/schema/generated/resolvers.generated.ts
+++ b/backend/src/schema/generated/resolvers.generated.ts
@@ -1,32 +1,7 @@
+import * as Types from './typeDefs.generated';
 import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
+import { User, Notification } from './typeDefs.generated';
 import { GraphQLContext } from '../../context';
-import type {
-  Maybe,
-  Scalars,
-  Journey,
-  JourneyMonitor,
-  JourneysResult,
-  JourneyExpiryNotification,
-  PriceAlertNotification,
-  User,
-  PresignedUrl,
-  Notification,
-  MutationCreateUserArgs,
-  MutationDeleteJourneyMonitorArgs,
-  MutationDeleteUserArgs,
-  MutationMarkNotificationAsReadArgs,
-  MutationMonitorJourneyArgs,
-  MutationSendEmailNotificationArgs,
-  MutationUpdateJourneyMonitorArgs,
-  MutationUpdateUserProfilePictureArgs,
-  MutationUpdateUserSettingsArgs,
-  QueryJourneysArgs,
-  QueryLocationsArgs,
-  QueryUserArgs,
-  QueryUserProfilePicturePresignedUrlArgs,
-  UserJourneyMonitorsArgs,
-  UserNotificationsArgs,
-} from './typeDefs.generated';
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
@@ -34,9 +9,12 @@ export type ResolverTypeWrapper<T> = Promise<T> | T;
 export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
-export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
-  | ResolverFn<TResult, TParent, TContext, TArgs>
-  | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+export type Resolver<
+  TResult,
+  TParent = Record<PropertyKey, never>,
+  TContext = Record<PropertyKey, never>,
+  TArgs = Record<PropertyKey, never>,
+> = ResolverFn<TResult, TParent, TContext, TArgs> | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
@@ -73,17 +51,23 @@ export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, 
   | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
   | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
 
-export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+export type SubscriptionResolver<
+  TResult,
+  TKey extends string,
+  TParent = Record<PropertyKey, never>,
+  TContext = Record<PropertyKey, never>,
+  TArgs = Record<PropertyKey, never>,
+> =
   | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
   | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
 
-export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+export type TypeResolveFn<TTypes, TParent = Record<PropertyKey, never>, TContext = Record<PropertyKey, never>> = (
   parent: TParent,
   context: TContext,
   info: GraphQLResolveInfo
-) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+) => Types.Maybe<TTypes> | Promise<Types.Maybe<TTypes>>;
 
-export type IsTypeOfResolverFn<T = {}, TContext = {}> = (
+export type IsTypeOfResolverFn<T = Record<PropertyKey, never>, TContext = Record<PropertyKey, never>> = (
   obj: T,
   context: TContext,
   info: GraphQLResolveInfo
@@ -91,7 +75,12 @@ export type IsTypeOfResolverFn<T = {}, TContext = {}> = (
 
 export type NextResolverFn<T> = () => Promise<T>;
 
-export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+export type DirectiveResolverFn<
+  TResult = Record<PropertyKey, never>,
+  TParent = Record<PropertyKey, never>,
+  TContext = Record<PropertyKey, never>,
+  TArgs = Record<PropertyKey, never>,
+> = (
   next: NextResolverFn<TResult>,
   parent: TParent,
   args: TArgs,
@@ -99,52 +88,49 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
   info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
 
-/** Mapping of interface types */
-export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
-  Notification: JourneyExpiryNotification | PriceAlertNotification;
-};
-
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
-  Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
-  DateTime: ResolverTypeWrapper<Scalars['DateTime']['output']>;
-  File: ResolverTypeWrapper<Scalars['File']['output']>;
-  Float: ResolverTypeWrapper<Scalars['Float']['output']>;
-  ID: ResolverTypeWrapper<Scalars['ID']['output']>;
-  Int: ResolverTypeWrapper<Scalars['Int']['output']>;
-  Journey: ResolverTypeWrapper<Journey>;
-  JourneyExpiryNotification: ResolverTypeWrapper<JourneyExpiryNotification>;
-  JourneyMonitor: ResolverTypeWrapper<JourneyMonitor>;
-  JourneysResult: ResolverTypeWrapper<JourneysResult>;
-  Location: ResolverTypeWrapper<Location>;
-  Mutation: ResolverTypeWrapper<{}>;
-  Notification: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Notification']>;
-  PresignedUrl: ResolverTypeWrapper<PresignedUrl>;
-  PriceAlertNotification: ResolverTypeWrapper<PriceAlertNotification>;
-  Query: ResolverTypeWrapper<{}>;
-  String: ResolverTypeWrapper<Scalars['String']['output']>;
+  Boolean: ResolverTypeWrapper<Types.Scalars['Boolean']['output']>;
+  DateTime: ResolverTypeWrapper<Types.Scalars['DateTime']['output']>;
+  File: ResolverTypeWrapper<Types.Scalars['File']['output']>;
+  Float: ResolverTypeWrapper<Types.Scalars['Float']['output']>;
+  ID: ResolverTypeWrapper<Types.Scalars['ID']['output']>;
+  Int: ResolverTypeWrapper<Types.Scalars['Int']['output']>;
+  Journey: ResolverTypeWrapper<Types.Journey>;
+  JourneyExpiryNotification: ResolverTypeWrapper<Types.JourneyExpiryNotification>;
+  JourneyMonitor: ResolverTypeWrapper<Types.JourneyMonitor>;
+  JourneyStaleNotification: ResolverTypeWrapper<Types.JourneyStaleNotification>;
+  JourneysResult: ResolverTypeWrapper<Types.JourneysResult>;
+  Location: ResolverTypeWrapper<Types.Location>;
+  Mutation: ResolverTypeWrapper<Record<PropertyKey, never>>;
+  Notification: ResolverTypeWrapper<Notification>;
+  PresignedUrl: ResolverTypeWrapper<Types.PresignedUrl>;
+  PriceAlertNotification: ResolverTypeWrapper<Types.PriceAlertNotification>;
+  Query: ResolverTypeWrapper<Record<PropertyKey, never>>;
+  String: ResolverTypeWrapper<Types.Scalars['String']['output']>;
   User: ResolverTypeWrapper<User>;
 };
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
-  Boolean: Scalars['Boolean']['output'];
-  DateTime: Scalars['DateTime']['output'];
-  File: Scalars['File']['output'];
-  Float: Scalars['Float']['output'];
-  ID: Scalars['ID']['output'];
-  Int: Scalars['Int']['output'];
-  Journey: Journey;
-  JourneyExpiryNotification: JourneyExpiryNotification;
-  JourneyMonitor: JourneyMonitor;
-  JourneysResult: JourneysResult;
-  Location: Location;
-  Mutation: {};
-  Notification: ResolversInterfaceTypes<ResolversParentTypes>['Notification'];
-  PresignedUrl: PresignedUrl;
-  PriceAlertNotification: PriceAlertNotification;
-  Query: {};
-  String: Scalars['String']['output'];
+  Boolean: Types.Scalars['Boolean']['output'];
+  DateTime: Types.Scalars['DateTime']['output'];
+  File: Types.Scalars['File']['output'];
+  Float: Types.Scalars['Float']['output'];
+  ID: Types.Scalars['ID']['output'];
+  Int: Types.Scalars['Int']['output'];
+  Journey: Types.Journey;
+  JourneyExpiryNotification: Types.JourneyExpiryNotification;
+  JourneyMonitor: Types.JourneyMonitor;
+  JourneyStaleNotification: Types.JourneyStaleNotification;
+  JourneysResult: Types.JourneysResult;
+  Location: Types.Location;
+  Mutation: Record<PropertyKey, never>;
+  Notification: Notification;
+  PresignedUrl: Types.PresignedUrl;
+  PriceAlertNotification: Types.PriceAlertNotification;
+  Query: Record<PropertyKey, never>;
+  String: Types.Scalars['String']['output'];
   User: User;
 };
 
@@ -160,26 +146,26 @@ export type JourneyResolvers<
   ContextType = GraphQLContext,
   ParentType extends ResolversParentTypes['Journey'] = ResolversParentTypes['Journey'],
 > = {
-  arrival?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
-  departure?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
-  from?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  means?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
-  price?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  arrival?: Resolver<Types.Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  departure?: Resolver<Types.Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  fromId?: Resolver<Types.Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  means?: Resolver<Types.Maybe<Array<Types.Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
+  price?: Resolver<Types.Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   refreshToken?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  to?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+  toId?: Resolver<Types.Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 };
 
 export type JourneyExpiryNotificationResolvers<
   ContextType = GraphQLContext,
   ParentType extends ResolversParentTypes['JourneyExpiryNotification'] =
-  ResolversParentTypes['JourneyExpiryNotification'],
+    ResolversParentTypes['JourneyExpiryNotification'],
 > = {
+  from?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  journey?: Resolver<ResolversTypes['Journey'], ParentType, ContextType>;
   read?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   sent?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   timestamp?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  to?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   userId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -190,11 +176,38 @@ export type JourneyMonitorResolvers<
   ParentType extends ResolversParentTypes['JourneyMonitor'] = ResolversParentTypes['JourneyMonitor'],
 > = {
   expires?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  from?: Resolver<Types.Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  journey?: Resolver<Maybe<ResolversTypes['Journey']>, ParentType, ContextType>;
+  journey?: Resolver<Types.Maybe<ResolversTypes['Journey']>, ParentType, ContextType>;
   limitPrice?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  to?: Resolver<Types.Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  userId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+};
+
+export type JourneyStaleNotificationResolvers<
+  ContextType = GraphQLContext,
+  ParentType extends ResolversParentTypes['JourneyStaleNotification'] =
+    ResolversParentTypes['JourneyStaleNotification'],
+> = {
+  from?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  journeyId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  read?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  sent?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  timestamp?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  to?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  type?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   userId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type JourneysResultResolvers<
+  ContextType = GraphQLContext,
+  ParentType extends ResolversParentTypes['JourneysResult'] = ResolversParentTypes['JourneysResult'],
+> = {
+  earlierRef?: Resolver<Types.Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  journeys?: Resolver<Types.Maybe<Array<Types.Maybe<ResolversTypes['Journey']>>>, ParentType, ContextType>;
+  laterRef?: Resolver<Types.Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 };
 
 export type LocationResolvers<
@@ -204,7 +217,6 @@ export type LocationResolvers<
   id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type MutationResolvers<
@@ -212,59 +224,62 @@ export type MutationResolvers<
   ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation'],
 > = {
   createUser?: Resolver<
-    Maybe<ResolversTypes['User']>,
+    Types.Maybe<ResolversTypes['User']>,
     ParentType,
     ContextType,
-    RequireFields<MutationCreateUserArgs, 'email' | 'givenName' | 'id'>
+    RequireFields<Types.MutationCreateUserArgs, 'email' | 'givenName' | 'id'>
   >;
   deleteJourneyMonitor?: Resolver<
-    Maybe<ResolversTypes['JourneyMonitor']>,
+    Types.Maybe<ResolversTypes['JourneyMonitor']>,
     ParentType,
     ContextType,
-    RequireFields<MutationDeleteJourneyMonitorArgs, 'journeyId' | 'userId'>
+    RequireFields<Types.MutationDeleteJourneyMonitorArgs, 'journeyId' | 'userId'>
   >;
   deleteUser?: Resolver<
-    Maybe<ResolversTypes['User']>,
+    Types.Maybe<ResolversTypes['User']>,
     ParentType,
     ContextType,
-    RequireFields<MutationDeleteUserArgs, 'id'>
+    RequireFields<Types.MutationDeleteUserArgs, 'id'>
   >;
   markNotificationAsRead?: Resolver<
-    Maybe<ResolversTypes['Notification']>,
+    Types.Maybe<ResolversTypes['Notification']>,
     ParentType,
     ContextType,
-    RequireFields<MutationMarkNotificationAsReadArgs, 'notificationId' | 'userId'>
+    RequireFields<Types.MutationMarkNotificationAsReadArgs, 'notificationId' | 'userId'>
   >;
   monitorJourney?: Resolver<
-    Maybe<ResolversTypes['JourneyMonitor']>,
+    Types.Maybe<ResolversTypes['JourneyMonitor']>,
     ParentType,
     ContextType,
-    RequireFields<MutationMonitorJourneyArgs, 'expires' | 'limitPrice' | 'refreshToken' | 'userId'>
+    RequireFields<
+      Types.MutationMonitorJourneyArgs,
+      'departure' | 'expires' | 'fromId' | 'limitPrice' | 'refreshToken' | 'toId' | 'userId'
+    >
   >;
   sendEmailNotification?: Resolver<
-    Maybe<ResolversTypes['Notification']>,
+    Types.Maybe<ResolversTypes['Notification']>,
     ParentType,
     ContextType,
-    RequireFields<MutationSendEmailNotificationArgs, 'notificationId' | 'userId'>
+    RequireFields<Types.MutationSendEmailNotificationArgs, 'notificationId' | 'userId'>
   >;
   updateJourneyMonitor?: Resolver<
-    Maybe<ResolversTypes['JourneyMonitor']>,
+    Types.Maybe<ResolversTypes['JourneyMonitor']>,
     ParentType,
     ContextType,
-    RequireFields<MutationUpdateJourneyMonitorArgs, 'journeyId' | 'userId'>
+    RequireFields<Types.MutationUpdateJourneyMonitorArgs, 'journeyId' | 'userId'>
   >;
-  updateJourneyMonitors?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  updateJourneyMonitors?: Resolver<Types.Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   updateUserProfilePicture?: Resolver<
-    Maybe<ResolversTypes['User']>,
+    Types.Maybe<ResolversTypes['User']>,
     ParentType,
     ContextType,
-    RequireFields<MutationUpdateUserProfilePictureArgs, 'id' | 'image'>
+    RequireFields<Types.MutationUpdateUserProfilePictureArgs, 'id' | 'image'>
   >;
   updateUserSettings?: Resolver<
-    Maybe<ResolversTypes['User']>,
+    Types.Maybe<ResolversTypes['User']>,
     ParentType,
     ContextType,
-    RequireFields<MutationUpdateUserSettingsArgs, 'emailNotificationsEnabled' | 'id'>
+    RequireFields<Types.MutationUpdateUserSettingsArgs, 'emailNotificationsEnabled' | 'id'>
   >;
 };
 
@@ -272,13 +287,11 @@ export type NotificationResolvers<
   ContextType = GraphQLContext,
   ParentType extends ResolversParentTypes['Notification'] = ResolversParentTypes['Notification'],
 > = {
-  __resolveType: TypeResolveFn<'JourneyExpiryNotification' | 'PriceAlertNotification', ParentType, ContextType>;
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  read?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  sent?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  timestamp?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
-  type?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  userId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  __resolveType: TypeResolveFn<
+    'JourneyExpiryNotification' | 'JourneyStaleNotification' | 'PriceAlertNotification',
+    ParentType,
+    ContextType
+  >;
 };
 
 export type PresignedUrlResolvers<
@@ -286,8 +299,7 @@ export type PresignedUrlResolvers<
   ParentType extends ResolversParentTypes['PresignedUrl'] = ResolversParentTypes['PresignedUrl'],
 > = {
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+  url?: Resolver<Types.Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 };
 
 export type PriceAlertNotificationResolvers<
@@ -309,23 +321,28 @@ export type QueryResolvers<
   ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query'],
 > = {
   journeys?: Resolver<
-    Maybe<ResolversTypes['JourneysResult']>,
+    Types.Maybe<ResolversTypes['JourneysResult']>,
     ParentType,
     ContextType,
-    RequireFields<QueryJourneysArgs, 'departure' | 'from' | 'to'>
+    RequireFields<Types.QueryJourneysArgs, 'departure' | 'from' | 'to'>
   >;
   locations?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['Location']>>>,
+    Types.Maybe<Array<Types.Maybe<ResolversTypes['Location']>>>,
     ParentType,
     ContextType,
-    RequireFields<QueryLocationsArgs, 'query'>
+    RequireFields<Types.QueryLocationsArgs, 'query'>
   >;
-  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserArgs, 'id'>>;
-  userProfilePicturePresignedUrl?: Resolver<
-    Maybe<ResolversTypes['PresignedUrl']>,
+  user?: Resolver<
+    Types.Maybe<ResolversTypes['User']>,
     ParentType,
     ContextType,
-    RequireFields<QueryUserProfilePicturePresignedUrlArgs, 'id'>
+    RequireFields<Types.QueryUserArgs, 'id'>
+  >;
+  userProfilePicturePresignedUrl?: Resolver<
+    Types.Maybe<ResolversTypes['PresignedUrl']>,
+    ParentType,
+    ContextType,
+    RequireFields<Types.QueryUserProfilePicturePresignedUrlArgs, 'id'>
   >;
 };
 
@@ -335,23 +352,22 @@ export type UserResolvers<
 > = {
   email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   emailNotificationsEnabled?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  familyName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  familyName?: Resolver<Types.Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   givenName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   journeyMonitors?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['JourneyMonitor']>>>,
+    Types.Maybe<Array<Types.Maybe<ResolversTypes['JourneyMonitor']>>>,
     ParentType,
     ContextType,
-    Partial<UserJourneyMonitorsArgs>
+    Partial<Types.UserJourneyMonitorsArgs>
   >;
   notifications?: Resolver<
-    Maybe<Array<Maybe<ResolversTypes['Notification']>>>,
+    Types.Maybe<Array<Types.Maybe<ResolversTypes['Notification']>>>,
     ParentType,
     ContextType,
-    Partial<UserNotificationsArgs>
+    Partial<Types.UserNotificationsArgs>
   >;
-  profilePicture?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+  profilePicture?: Resolver<Types.Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 };
 
 export type Resolvers<ContextType = GraphQLContext> = {
@@ -360,6 +376,8 @@ export type Resolvers<ContextType = GraphQLContext> = {
   Journey?: JourneyResolvers<ContextType>;
   JourneyExpiryNotification?: JourneyExpiryNotificationResolvers<ContextType>;
   JourneyMonitor?: JourneyMonitorResolvers<ContextType>;
+  JourneyStaleNotification?: JourneyStaleNotificationResolvers<ContextType>;
+  JourneysResult?: JourneysResultResolvers<ContextType>;
   Location?: LocationResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   Notification?: NotificationResolvers<ContextType>;

--- a/backend/src/schema/generated/typeDefs.generated.ts
+++ b/backend/src/schema/generated/typeDefs.generated.ts
@@ -7,33 +7,34 @@ export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> =
 export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string; }
-  String: { input: string; output: string; }
-  Boolean: { input: boolean; output: boolean; }
-  Int: { input: number; output: number; }
-  Float: { input: number; output: number; }
-  DateTime: { input: any; output: any; }
-  File: { input: File; output: File; }
+  ID: { input: string; output: string };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+  DateTime: { input: any; output: any };
+  File: { input: File; output: File };
 };
 
 export type Journey = {
   __typename?: 'Journey';
   arrival?: Maybe<Scalars['DateTime']['output']>;
   departure?: Maybe<Scalars['DateTime']['output']>;
-  from?: Maybe<Scalars['String']['output']>;
+  fromId?: Maybe<Scalars['String']['output']>;
   means?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   price?: Maybe<Scalars['Float']['output']>;
   refreshToken: Scalars['String']['output'];
-  to?: Maybe<Scalars['String']['output']>;
+  toId?: Maybe<Scalars['String']['output']>;
 };
 
 export type JourneyExpiryNotification = Notification & {
   __typename?: 'JourneyExpiryNotification';
+  from: Scalars['String']['output'];
   id: Scalars['ID']['output'];
-  journey: Journey;
   read: Scalars['Boolean']['output'];
   sent: Scalars['Boolean']['output'];
   timestamp: Scalars['DateTime']['output'];
+  to: Scalars['String']['output'];
   type: Scalars['ID']['output'];
   userId: Scalars['ID']['output'];
 };
@@ -41,9 +42,24 @@ export type JourneyExpiryNotification = Notification & {
 export type JourneyMonitor = {
   __typename?: 'JourneyMonitor';
   expires: Scalars['DateTime']['output'];
+  from?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   journey?: Maybe<Journey>;
   limitPrice: Scalars['Float']['output'];
+  to?: Maybe<Scalars['String']['output']>;
+  userId: Scalars['ID']['output'];
+};
+
+export type JourneyStaleNotification = Notification & {
+  __typename?: 'JourneyStaleNotification';
+  from: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  journeyId: Scalars['ID']['output'];
+  read: Scalars['Boolean']['output'];
+  sent: Scalars['Boolean']['output'];
+  timestamp: Scalars['DateTime']['output'];
+  to: Scalars['String']['output'];
+  type: Scalars['ID']['output'];
   userId: Scalars['ID']['output'];
 };
 
@@ -75,7 +91,6 @@ export type Mutation = {
   updateUserSettings?: Maybe<User>;
 };
 
-
 export type MutationCreateUserArgs = {
   email: Scalars['String']['input'];
   familyName?: InputMaybe<Scalars['String']['input']>;
@@ -83,49 +98,44 @@ export type MutationCreateUserArgs = {
   id: Scalars['ID']['input'];
 };
 
-
 export type MutationDeleteJourneyMonitorArgs = {
   journeyId: Scalars['ID']['input'];
   userId: Scalars['ID']['input'];
 };
 
-
 export type MutationDeleteUserArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type MutationMarkNotificationAsReadArgs = {
   notificationId: Scalars['ID']['input'];
   userId: Scalars['ID']['input'];
 };
 
-
 export type MutationMonitorJourneyArgs = {
+  departure: Scalars['DateTime']['input'];
   expires: Scalars['DateTime']['input'];
+  fromId: Scalars['String']['input'];
   limitPrice: Scalars['Float']['input'];
   refreshToken: Scalars['String']['input'];
+  toId: Scalars['String']['input'];
   userId: Scalars['ID']['input'];
 };
-
 
 export type MutationSendEmailNotificationArgs = {
   notificationId: Scalars['ID']['input'];
   userId: Scalars['ID']['input'];
 };
 
-
 export type MutationUpdateJourneyMonitorArgs = {
   journeyId: Scalars['ID']['input'];
   userId: Scalars['ID']['input'];
 };
 
-
 export type MutationUpdateUserProfilePictureArgs = {
   id: Scalars['ID']['input'];
   image: Scalars['File']['input'];
 };
-
 
 export type MutationUpdateUserSettingsArgs = {
   emailNotificationsEnabled: Scalars['Boolean']['input'];
@@ -166,7 +176,6 @@ export type Query = {
   userProfilePicturePresignedUrl?: Maybe<PresignedUrl>;
 };
 
-
 export type QueryJourneysArgs = {
   departure: Scalars['DateTime']['input'];
   earlierThan?: InputMaybe<Scalars['String']['input']>;
@@ -175,16 +184,13 @@ export type QueryJourneysArgs = {
   to: Scalars['String']['input'];
 };
 
-
 export type QueryLocationsArgs = {
   query: Scalars['String']['input'];
 };
 
-
 export type QueryUserArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type QueryUserProfilePicturePresignedUrlArgs = {
   id: Scalars['ID']['input'];
@@ -202,11 +208,9 @@ export type User = {
   profilePicture?: Maybe<Scalars['String']['output']>;
 };
 
-
 export type UserJourneyMonitorsArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
 };
-
 
 export type UserNotificationsArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;

--- a/backend/src/schema/schema.graphql
+++ b/backend/src/schema/schema.graphql
@@ -78,7 +78,20 @@ type JourneyExpiryNotification implements Notification {
   timestamp: DateTime!
   read: Boolean!
   sent: Boolean!
-  journey: Journey!
+  from: String!
+  to: String!
+}
+
+type JourneyStaleNotification implements Notification {
+  id: ID!
+  type: ID!
+  userId: ID!
+  timestamp: DateTime!
+  read: Boolean!
+  sent: Boolean!
+  journeyId: ID!
+  from: String!
+  to: String!
 }
 
 ## Mutations
@@ -101,8 +114,8 @@ type JourneysResult {
 
 type Journey {
   refreshToken: String!
-  from: String
-  to: String
+  fromId: String
+  toId: String
   departure: DateTime
   arrival: DateTime
   means: [String]
@@ -115,6 +128,8 @@ type JourneyMonitor {
   limitPrice: Float!
   expires: DateTime!
   journey: Journey
+  from: String
+  to: String
 }
 
 ## Queries
@@ -126,7 +141,15 @@ extend type Query {
 ## Mutations
 
 extend type Mutation {
-  monitorJourney(userId: ID!, refreshToken: String!, limitPrice: Float!, expires: DateTime!): JourneyMonitor
+  monitorJourney(
+    userId: ID!
+    refreshToken: String!
+    limitPrice: Float!
+    expires: DateTime!
+    fromId: String!
+    toId: String!
+    departure: DateTime!
+  ): JourneyMonitor
 }
 
 extend type Mutation {

--- a/frontend/src/api/journey.tsx
+++ b/frontend/src/api/journey.tsx
@@ -4,6 +4,8 @@ export const JourneySearchQuery = gql`
   query ($departure: DateTime!, $from: String!, $to: String!, $earlierThan: String, $laterThan: String) {
     journeys(departure: $departure, from: $from, to: $to, earlierThan: $earlierThan, laterThan: $laterThan) {
       journeys {
+        fromId
+        toId
         departure
         arrival
         refreshToken
@@ -17,8 +19,24 @@ export const JourneySearchQuery = gql`
 `;
 
 export const MonitorJourney = gql`
-  mutation ($userId: ID!, $refreshToken: String!, $limitPrice: Float!, $expires: DateTime!) {
-    monitorJourney(userId: $userId, refreshToken: $refreshToken, limitPrice: $limitPrice, expires: $expires) {
+  mutation (
+    $userId: ID!
+    $refreshToken: String!
+    $limitPrice: Float!
+    $expires: DateTime!
+    $fromId: String!
+    $toId: String!
+    $departure: DateTime!
+  ) {
+    monitorJourney(
+      userId: $userId
+      refreshToken: $refreshToken
+      limitPrice: $limitPrice
+      expires: $expires
+      fromId: $fromId
+      toId: $toId
+      departure: $departure
+    ) {
       id
     }
   }

--- a/frontend/src/api/user.tsx
+++ b/frontend/src/api/user.tsx
@@ -63,17 +63,18 @@ export const UserNotificationsQuery = gql`
         ... on PriceAlertNotification {
           journeyMonitor {
             id
-            journey {
-              from
-              to
-            }
-          }
-        }
-        ... on JourneyExpiryNotification {
-          journey {
             from
             to
           }
+        }
+        ... on JourneyExpiryNotification {
+          from
+          to
+        }
+        ... on JourneyStaleNotification {
+          journeyId
+          from
+          to
         }
       }
     }
@@ -87,10 +88,10 @@ export const UserJourneysQuery = gql`
       journeyMonitors {
         id
         limitPrice
+        from
+        to
         journey {
           refreshToken
-          from
-          to
           departure
           arrival
           means

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -194,10 +194,13 @@ const Header = () => {
         handleNotificationClicked={(notification: Notification) => {
           if (notification?.type === 'PRICE_ALERT') {
             // Navigate to JourneysPage with the correct accordion open
-            navigate(`/journeys#${notification.journeyMonitor.id}`);
+            navigate(`/journeys#${notification.journeyMonitor?.id}`);
           } else if (notification?.type === 'JOURNEY_EXPIRED') {
             // Navigate to JourneysPage
             navigate(`/journeys`);
+          } else if (notification?.type === 'JOURNEY_STALE') {
+            // Navigate to the specific journey monitor so the user can delete it
+            navigate(`/journeys#${notification.journeyId}`);
           }
           handleNotificationClose();
         }}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -200,7 +200,7 @@ const Header = () => {
             navigate(`/journeys`);
           } else if (notification?.type === 'JOURNEY_STALE') {
             // Navigate to the specific journey monitor so the user can delete it
-            navigate(`/journeys#${notification.journeyId}`);
+            navigate(notification.journeyId ? `/journeys#${notification.journeyId}` : '/journeys');
           }
           handleNotificationClose();
         }}

--- a/frontend/src/components/NotificationPopover.tsx
+++ b/frontend/src/components/NotificationPopover.tsx
@@ -10,16 +10,13 @@ export interface Notification {
   type: string;
   read: boolean;
   timestamp: Date;
-  journey?: {
+  from?: string;
+  to?: string;
+  journeyId?: string;
+  journeyMonitor?: {
+    id: string;
     from: string;
     to: string;
-  };
-  journeyMonitor: {
-    id: string;
-    journey: {
-      from: string;
-      to: string;
-    };
   };
 }
 
@@ -36,11 +33,15 @@ interface NotificationPopoverProps {
 const formatNotification = (notification: Notification) => {
   switch (notification.type) {
     case 'PRICE_ALERT':
-      return `Price limit reached for journey from ${notification.journeyMonitor.journey.from} to ${notification.journeyMonitor.journey.to}`;
+      return `Price limit reached for journey from ${notification.journeyMonitor?.from} to ${notification.journeyMonitor?.to}`;
     case 'JOURNEY_EXPIRED':
-      return notification.journey
-        ? `Watched journey from ${notification.journey.from} to ${notification.journey.to} expired`
+      return notification.from && notification.to
+        ? `Watched journey from ${notification.from} to ${notification.to} expired`
         : 'A watched journey has expired';
+    case 'JOURNEY_STALE':
+      return notification.from && notification.to
+        ? `Journey from ${notification.from} to ${notification.to} can no longer be tracked`
+        : 'A watched journey can no longer be tracked';
     default:
       return '';
   }

--- a/frontend/src/components/SearchResult.tsx
+++ b/frontend/src/components/SearchResult.tsx
@@ -29,8 +29,8 @@ import { AlertSeverity } from '../providers/AlertProvider';
 
 export interface Journey {
   refreshToken: string;
-  from: string;
-  to: string;
+  fromId: string;
+  toId: string;
   departure: string;
   arrival: string;
   means: string[];
@@ -94,6 +94,9 @@ const SearchResult: React.FC<Props> = ({
       refreshToken: refreshToken,
       limitPrice: parseFloat(limitPrice),
       expires: expires,
+      fromId: selectedJourney?.fromId,
+      toId: selectedJourney?.toId,
+      departure: selectedJourney?.departure,
     })
       .then((result) => {
         setLoading(false);

--- a/frontend/src/components/SearchResult.tsx
+++ b/frontend/src/components/SearchResult.tsx
@@ -85,7 +85,7 @@ const SearchResult: React.FC<Props> = ({
 
   const handleConfirmWatch = () => {
     setLoading(true);
-    const { refreshToken, departure } = selectedJourney!;
+    const { refreshToken, departure, fromId, toId } = selectedJourney!;
     const expires = new Date(departure);
     expires.setHours(expires.getHours() - 1);
 
@@ -94,9 +94,9 @@ const SearchResult: React.FC<Props> = ({
       refreshToken: refreshToken,
       limitPrice: parseFloat(limitPrice),
       expires: expires,
-      fromId: selectedJourney?.fromId,
-      toId: selectedJourney?.toId,
-      departure: selectedJourney?.departure,
+      fromId: fromId,
+      toId: toId,
+      departure: departure,
     })
       .then((result) => {
         setLoading(false);

--- a/frontend/src/pages/JourneysPage.tsx
+++ b/frontend/src/pages/JourneysPage.tsx
@@ -23,9 +23,9 @@ import useAlert from '../hooks/useAlert';
 interface Journey {
   id: string;
   limitPrice: number;
+  from: string;
+  to: string;
   journey: {
-    from: string;
-    to: string;
     refreshToken: string;
     departure: string;
     arrival: string;
@@ -103,7 +103,7 @@ const JourneysPage: React.FC = () => {
           <Typography variant="body1">Loading journeys...</Typography>
         ) : userJourneysResult && userJourneysResult.user.journeyMonitors.length > 0 ? (
           <List>
-            {userJourneysResult.user.journeyMonitors.map(({ id, limitPrice, journey }: Journey) => (
+            {userJourneysResult.user.journeyMonitors.map(({ id, limitPrice, from, to, journey }: Journey) => (
               <ListItem key={id} alignItems="flex-start">
                 <Accordion
                   sx={{ width: '100%' }}
@@ -114,7 +114,7 @@ const JourneysPage: React.FC = () => {
                     <Grid container justifyContent="space-between" alignItems="center" spacing={2}>
                       <Grid size={{ sm: 6, xs: 12 }}>
                         <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
-                          {`${journey.from} to ${journey.to}`}
+                          {`${from} to ${to}`}
                         </Typography>
                       </Grid>
                       <Grid size={{ sm: 3, xs: 6 }} sx={{ textAlign: 'right' }}>

--- a/frontend/src/pages/JourneysPage.tsx
+++ b/frontend/src/pages/JourneysPage.tsx
@@ -9,8 +9,11 @@ import {
   ListItem,
   IconButton,
   CircularProgress,
+  Chip,
+  Alert,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import { useMutation, useQuery } from 'urql';
 import { UserJourneysQuery } from '../api/user';
 import { AuthContext } from '../providers/AuthProvider';
@@ -31,7 +34,7 @@ interface Journey {
     arrival: string;
     means: string[];
     price: number;
-  };
+  } | null;
 }
 
 const JourneysPage: React.FC = () => {
@@ -121,31 +124,49 @@ const JourneysPage: React.FC = () => {
                         <Typography variant="body2">{`Limit Price: €${limitPrice.toFixed(2)}`}</Typography>
                       </Grid>
                       <Grid size={{ sm: 3, xs: 6 }} sx={{ textAlign: 'right' }}>
-                        <Typography
-                          variant="body2"
-                          sx={{
-                            color: journey.price !== null ? (journey.price > limitPrice ? 'red' : 'green') : 'inherit',
-                          }}
-                        >
-                          Current Price: {journey.price !== null ? `€${journey.price.toFixed(2)}` : 'n/a'}
-                        </Typography>
+                        {journey ? (
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              color:
+                                journey.price !== null ? (journey.price > limitPrice ? 'red' : 'green') : 'inherit',
+                            }}
+                          >
+                            Current Price: {journey.price !== null ? `€${journey.price.toFixed(2)}` : 'n/a'}
+                          </Typography>
+                        ) : (
+                          <Chip
+                            icon={<WarningAmberIcon />}
+                            label="No longer tracked"
+                            color="warning"
+                            size="small"
+                            variant="outlined"
+                          />
+                        )}
                       </Grid>
                     </Grid>
                   </AccordionSummary>
                   <AccordionDetails>
-                    <Grid container spacing={2}>
-                      <Grid size={12}>
-                        <Typography variant="body2">{`Departure: ${formatDateTime(journey.departure)}`}</Typography>
+                    {journey ? (
+                      <Grid container spacing={2}>
+                        <Grid size={12}>
+                          <Typography variant="body2">{`Departure: ${formatDateTime(journey.departure)}`}</Typography>
+                        </Grid>
+                        <Grid size={12}>
+                          <Typography variant="body2">{`Arrival: ${formatDateTime(journey.arrival)}`}</Typography>
+                        </Grid>
+                        <Grid size={12}>
+                          <Typography variant="body2">{`Means of Transport: ${journey.means
+                            .map((mean: string) => (mean === 'walk' ? '\u{1F6B6}' : mean))
+                            .join(' \u{2192} ')}`}</Typography>
+                        </Grid>
                       </Grid>
-                      <Grid size={12}>
-                        <Typography variant="body2">{`Arrival: ${formatDateTime(journey.arrival)}`}</Typography>
-                      </Grid>
-                      <Grid size={12}>
-                        <Typography variant="body2">{`Means of Transport: ${journey.means
-                          .map((mean: string) => (mean === 'walk' ? '\u{1F6B6}' : mean))
-                          .join(' \u{2192} ')}`}</Typography>
-                      </Grid>
-                    </Grid>
+                    ) : (
+                      <Alert severity="warning" icon={<WarningAmberIcon />}>
+                        This journey can no longer be tracked — it may have been cancelled or rescheduled. You can
+                        safely remove it from your watchlist.
+                      </Alert>
+                    )}
                   </AccordionDetails>
                 </Accordion>
                 <IconButton

--- a/frontend/src/pages/JourneysPage.tsx
+++ b/frontend/src/pages/JourneysPage.tsx
@@ -26,8 +26,8 @@ import useAlert from '../hooks/useAlert';
 interface Journey {
   id: string;
   limitPrice: number;
-  from: string;
-  to: string;
+  from?: string | null;
+  to?: string | null;
   journey: {
     refreshToken: string;
     departure: string;
@@ -117,7 +117,7 @@ const JourneysPage: React.FC = () => {
                     <Grid container justifyContent="space-between" alignItems="center" spacing={2}>
                       <Grid size={{ sm: 6, xs: 12 }}>
                         <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
-                          {`${from} to ${to}`}
+                          {`${from ?? 'Unknown'} to ${to ?? 'Unknown'}`}
                         </Typography>
                       </Grid>
                       <Grid size={{ sm: 3, xs: 6 }} sx={{ textAlign: 'right' }}>

--- a/infrastructure/lib/backend.ts
+++ b/infrastructure/lib/backend.ts
@@ -47,9 +47,16 @@ export class Backend extends Construct {
       ],
     });
 
-    // Create SQS queue
+    // Create DLQ for failed messages
+    const dlq = new sqs.Queue(this, 'TrainPriceMonitorDLQ', {
+      retentionPeriod: cdk.Duration.days(14),
+      visibilityTimeout: cdk.Duration.seconds(60),
+    });
+
+    // Create SQS queue with DLQ
     const queue = new sqs.Queue(this, 'TrainPriceMonitorQueue', {
-      visibilityTimeout: cdk.Duration.seconds(60), // Set visibility timeout as needed
+      visibilityTimeout: cdk.Duration.seconds(60),
+      deadLetterQueue: { queue: dlq, maxReceiveCount: 3 },
     });
 
     // Create Lambda function

--- a/infrastructure/mise.toml
+++ b/infrastructure/mise.toml
@@ -6,4 +6,5 @@ run = "npm test"
 
 [tasks.deploy]
 description = "Deploy all CDK stacks to AWS"
+depends = ["//frontend:build"]
 run = "npx cdk deploy --all --require-approval never"


### PR DESCRIPTION
## Summary

### fix(sqs): prevent infinite retry loop with error handling and DLQ
The SQS Lambda handler was rethrowing errors from `updateJourneyMonitors`, causing SQS to retry indefinitely. The handler now throws on genuine GraphQL execution errors (transient failures like DynamoDB/HAFAS timeouts) so SQS retries up to `maxReceiveCount: 3` before routing to a new DLQ. Expected outcomes such as stale journeys are handled gracefully inside the resolver without surfacing errors, so they are never retried.

### feat(backend): add JOURNEY_STALE notification and clean up Journey schema
- Removed redundant `from`/`to` station name fields from the `Journey` DynamoDB entity and mutation arguments; canonical names are now resolved at query time via HAFAS or `getStationById`
- Added `fromId`, `toId`, and `departure` fields to `Journey` to support token recovery
- Added a `JOURNEY_STALE` notification type (with deduplication and email) emitted when a journey's refresh token can no longer be recovered — e.g. the train was cancelled or rescheduled
- Recovery logic queries HAFAS with the stored station IDs and departure time, then picks the candidate whose planned departure is closest to the original to avoid reattaching to the wrong service on a busy route

### feat(frontend): handle JOURNEY_STALE notifications and update Journey queries
- Updated GraphQL queries/mutations to remove `from`/`to` from journey inputs; station names are read from `JourneyMonitor` fields
- `NotificationPopover` and `Header` handle `JOURNEY_STALE` notifications
- Journey Watchlist shows a warning `Chip` ("No longer tracked") in the summary row and a descriptive MUI `Alert` in the expanded panel when `journey` is `null`, instead of crashing

### fix(infrastructure): ensure frontend is built before CDK deploy
Added `depends = ["//frontend:build"]` to the deploy task in `infrastructure/mise.toml` so the frontend bundle is always fresh when CDK synths the S3 asset.

### fix(backend): scope response cache per user
`useResponseCache` was configured with `session: () => null`, causing all users to share a single in-memory cache partition. A cached empty `journeyMonitors: []` response would be served to everyone indefinitely. The session function now extracts the JWT `sub` claim from the `Authorization` header to give each user an independent cache partition.

### chore: add local E2E testing skill
Added `.opencode/skills/local-e2e-testing/SKILL.md` with a guide for running end-to-end tests locally using the Playwright MCP browser. Credentials are read from `process.env.TEST_USER_EMAIL` / `process.env.TEST_USER_PASSWORD` (sourced from the root `.env` file) — no secrets are hardcoded.
