### PR TITLE
fix: prevent direct link redirect by waiting for auth check completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ request.json
 
 # plans
 .github/plans/
+.opencode/plans/
 
 # stats
 stats/

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -8,6 +8,7 @@ import { AlertSeverity } from './AlertProvider';
 
 interface AuthContextType {
   user: UserData | null;
+  isInitialCheckDone: boolean;
   signIn: (email: string, password: string) => Promise<void>;
   signOut: () => Promise<void>;
   userProfilePictureUrl: string | undefined;
@@ -20,6 +21,7 @@ const AuthContext = createContext<AuthContextType>({} as AuthContextType);
 function AuthProvider({ children }: { children: React.ReactNode }) {
   const { addAlert } = useAlert();
   const [user, setUser] = useState<UserData | null>(null);
+  const [isInitialCheckDone, setIsInitialCheckDone] = useState<boolean>(false);
   const [userProfilePictureUrl, setUserProfilePictureUrl] = useState<string | undefined>(undefined);
   const [userProfilePictureUrlResult, reexecuteUserProfilePictureUrlQuery] = useQuery({
     query: UserProfilePictureUrlQuery,
@@ -36,6 +38,8 @@ function AuthProvider({ children }: { children: React.ReactNode }) {
       // eslint-disable-next-line no-console
       console.log(err);
       setUser(null);
+    } finally {
+      setIsInitialCheckDone(true);
     }
   };
 
@@ -109,6 +113,7 @@ function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const authValue: AuthContextType = {
     user,
+    isInitialCheckDone,
     signIn,
     signOut,
     userProfilePictureUrl,

--- a/frontend/src/utils/RouteGuard.tsx
+++ b/frontend/src/utils/RouteGuard.tsx
@@ -7,7 +7,11 @@ interface RouteGuardProps {
 }
 
 function RouteGuard({ children }: RouteGuardProps) {
-  const { user } = useContext(AuthContext);
+  const { user, isInitialCheckDone } = useContext(AuthContext);
+
+  if (!isInitialCheckDone) {
+    return <></>;
+  }
 
   if (!user) {
     return <Navigate to="/" />;

--- a/frontend/src/utils/RouteGuard.tsx
+++ b/frontend/src/utils/RouteGuard.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import { Navigate } from 'react-router-dom';
+import { CircularProgress, Box } from '@mui/material';
 import { AuthContext } from '../providers/AuthProvider';
 
 interface RouteGuardProps {
@@ -7,10 +8,20 @@ interface RouteGuardProps {
 }
 
 function RouteGuard({ children }: RouteGuardProps) {
-  const { user, isInitialCheckDone } = useContext(AuthContext);
+  const context = useContext(AuthContext);
+
+  if (!context) {
+    throw new Error('RouteGuard must be used within an AuthProvider');
+  }
+
+  const { user, isInitialCheckDone } = context;
 
   if (!isInitialCheckDone) {
-    return <></>;
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+        <CircularProgress />
+      </Box>
+    );
   }
 
   if (!user) {

--- a/frontend/src/utils/auth.tsx
+++ b/frontend/src/utils/auth.tsx
@@ -115,11 +115,12 @@ export type UserData = {
   [key: string]: string;
 };
 
-export async function getCurrentUser() {
-  return new Promise<UserData>((resolve, reject) => {
+export async function getCurrentUser(): Promise<UserData | null> {
+  return new Promise((resolve, reject) => {
     const cognitoUser = userPool.getCurrentUser();
 
     if (!cognitoUser) {
+      resolve(null);
       return;
     }
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where direct links to authenticated pages would incorrectly redirect users to the start page before the authentication check completed.

## Changes

- **AuthProvider.tsx**: Added `isInitialCheckDone` state variable to track when the initial authentication check has completed
  - New state is set to `true` in the `finally` block of the auth check
  - Exposed `isInitialCheckDone` via the AuthContext for use in route protection

- **RouteGuard.tsx**: Updated to wait for auth check completion before evaluating user authentication
  - Now checks `isInitialCheckDone` before redirecting unauthenticated users
  - Returns empty fragment while auth check is in progress

## Problem Solved

Previously, when users accessed direct links to protected routes, the RouteGuard would immediately redirect to the start page because the auth state hadn't been determined yet. This change ensures the auth check completes before making any redirect decisions.