### PR TITLE
fix(backend): handle stale refresh tokens in journeyMonitors resolver

### DIFF
--- a/backend/src/resolvers/user.ts
+++ b/backend/src/resolvers/user.ts
@@ -110,8 +110,25 @@ export const userResolvers: UserResolvers = {
           refreshToken: string;
           userId: string;
           id: string;
+          fromId: string;
+          toId: string;
         }) => {
-          return await getJourneyMonitor(context, dbJourney);
+          try {
+            return await getJourneyMonitor(context, dbJourney);
+          } catch (error) {
+            Logger.error(`Failed to refresh journey ${dbJourney.id}: ${error}`);
+            const fromStation = await context.dbHafas.getStationById(dbJourney.fromId);
+            const toStation = await context.dbHafas.getStationById(dbJourney.toId);
+            return {
+              id: dbJourney.id,
+              userId: dbJourney.userId,
+              limitPrice: dbJourney.limitPrice,
+              expires: dbJourney.expires,
+              from: fromStation?.name ?? undefined,
+              to: toStation?.name ?? undefined,
+              journey: undefined,
+            } as JourneyMonitor;
+          }
         }
       )
     );
@@ -331,6 +348,8 @@ export async function getJourneyMonitor(
     refreshToken: string;
     userId: string;
     id: string;
+    fromId: string;
+    toId: string;
   }
 ): Promise<JourneyMonitor> {
   const journey = await context.dbHafas.requeryJourney(dbJourney.refreshToken);

--- a/backend/src/resolvers/user.ts
+++ b/backend/src/resolvers/user.ts
@@ -102,7 +102,7 @@ export const userResolvers: UserResolvers = {
     if (!dbJourneys) {
       return [];
     }
-    const journeys: JourneyMonitor[] = await Promise.all(
+    const journeyResults = await Promise.allSettled(
       dbJourneys.map(
         async (dbJourney: {
           expires: string;
@@ -117,8 +117,17 @@ export const userResolvers: UserResolvers = {
             return await getJourneyMonitor(context, dbJourney);
           } catch (error) {
             Logger.error(`Failed to refresh journey ${dbJourney.id}: ${error}`);
-            const fromStation = await context.dbHafas.getStationById(dbJourney.fromId);
-            const toStation = await context.dbHafas.getStationById(dbJourney.toId);
+            let fromStation, toStation;
+            try {
+              fromStation = await context.dbHafas.getStationById(dbJourney.fromId);
+            } catch {
+              // ignore station lookup failure
+            }
+            try {
+              toStation = await context.dbHafas.getStationById(dbJourney.toId);
+            } catch {
+              // ignore station lookup failure
+            }
             return {
               id: dbJourney.id,
               userId: dbJourney.userId,
@@ -132,6 +141,10 @@ export const userResolvers: UserResolvers = {
         }
       )
     );
+
+    const journeys: JourneyMonitor[] = journeyResults
+      .filter((result): result is PromiseFulfilledResult<JourneyMonitor> => result.status === 'fulfilled')
+      .map((result) => result.value);
     journeys.sort(
       (a: JourneyMonitor, b: JourneyMonitor) =>
         (a.journey ? a.journey.departure.getTime() : Infinity) - (b.journey ? b.journey.departure.getTime() : Infinity)


### PR DESCRIPTION
## Problem

The `journeyMonitors` resolver uses bare `Promise.all` to fetch all journey details in parallel. When one journey has a stale refresh token, `requeryJourney` throws ("Not Found"), which rejects the entire `Promise.all` and returns `null` for the whole field. This causes all journeys to disappear from the UI — even healthy ones.

## Fix

Changed from `Promise.all` to `Promise.allSettled` with per-journey error handling:
- Each journey's `requeryJourney` call is wrapped in its own try/catch
- Failed journeys resolve with station name fallback via `context.dbHafas.getStationById()` (same pattern as `notificationTypes.ts:86-91`)
- If station name lookup also fails, falls back to `undefined` → UI displays "Unknown"
- Healthy journeys continue to render normally

Also extended `getJourneyMonitor` function signature to include `fromId`/`toId` fields for type consistency with the DynamoDB Journey entity.

## Verification

E2E tested with Playwright MCP:
- All 6 journey monitors render on `/journeys` page (including the one with stale token)
- Stale token journey shows "No longer tracked" chip instead of crashing
- No console errors or warnings