### PR TITLE
fix(frontend): delete journeys locally without backend refetch

### DIFF
--- a/frontend/src/pages/JourneysPage.tsx
+++ b/frontend/src/pages/JourneysPage.tsx
@@ -50,6 +50,11 @@ const JourneysPage: React.FC = () => {
 
   const [expandedJourneyIds, setExpandedJourneyIds] = useState<string[]>([]);
   const [loadingJourneyId, setLoadingJourneyId] = useState<string | null>(null);
+  const [deletedJourneyIds, setDeletedJourneyIds] = useState<string[]>([]);
+
+  const journeyMonitors =
+    userJourneysResult?.user?.journeyMonitors?.filter((journey: Journey) => !deletedJourneyIds.includes(journey.id)) ??
+    [];
 
   const toggleJourneyDetails = (journeyId: string) => {
     setExpandedJourneyIds((prevIds) => {
@@ -92,7 +97,7 @@ const JourneysPage: React.FC = () => {
       if (result.error) {
         addAlert(result.error.message, AlertSeverity.Error);
       } else {
-        reexecuteUserJourneysQuery({ requestPolicy: 'network-only' });
+        setDeletedJourneyIds((prev) => [...prev, id]);
       }
       setLoadingJourneyId(null);
     });
@@ -106,9 +111,9 @@ const JourneysPage: React.FC = () => {
       <Grid size={12}>
         {userJourneysFetching ? (
           <Typography variant="body1">Loading journeys...</Typography>
-        ) : userJourneysResult?.user?.journeyMonitors?.length > 0 ? (
+        ) : journeyMonitors.length > 0 ? (
           <List>
-            {userJourneysResult.user.journeyMonitors.map(({ id, limitPrice, from, to, journey }: Journey) => (
+            {journeyMonitors.map(({ id, limitPrice, from, to, journey }: Journey) => (
               <ListItem key={id} alignItems="flex-start">
                 <Accordion
                   sx={{ width: '100%' }}

--- a/frontend/src/pages/JourneysPage.tsx
+++ b/frontend/src/pages/JourneysPage.tsx
@@ -50,11 +50,10 @@ const JourneysPage: React.FC = () => {
 
   const [expandedJourneyIds, setExpandedJourneyIds] = useState<string[]>([]);
   const [loadingJourneyId, setLoadingJourneyId] = useState<string | null>(null);
-  const [deletedJourneyIds, setDeletedJourneyIds] = useState<string[]>([]);
+  const [deletedJourneyIds, setDeletedJourneyIds] = useState<Set<string>>(new Set());
 
   const journeyMonitors =
-    userJourneysResult?.user?.journeyMonitors?.filter((journey: Journey) => !deletedJourneyIds.includes(journey.id)) ??
-    [];
+    userJourneysResult?.user?.journeyMonitors?.filter((journey: Journey) => !deletedJourneyIds.has(journey.id)) ?? [];
 
   const toggleJourneyDetails = (journeyId: string) => {
     setExpandedJourneyIds((prevIds) => {
@@ -97,7 +96,11 @@ const JourneysPage: React.FC = () => {
       if (result.error) {
         addAlert(result.error.message, AlertSeverity.Error);
       } else {
-        setDeletedJourneyIds((prev) => [...prev, id]);
+        setDeletedJourneyIds((prev) => {
+          const next = new Set(prev);
+          next.add(id);
+          return next;
+        });
       }
       setLoadingJourneyId(null);
     });


### PR DESCRIPTION
## Problem

After deleting a journey from the watchlist (commit `3d4d0b2`), the UI triggered a full backend refetch via `reexecuteUserJourneysQuery({ requestPolicy: 'network-only' })`. This was unnecessary since the server already deleted the journey, and it caused an extra network request to reload the entire list.

## Solution

Instead of refetching the entire watchlist from the backend after deletion:

1. **Track deleted journey IDs locally** - Added `deletedJourneyIds` state array
2. **Filter journeys locally** - Created computed `journeyMonitors` list that filters out deleted IDs from the current query result
3. **Update delete handler** - `handleJourneyMonitorDelete` now adds the deleted ID to local state instead of calling `reexecuteUserJourneysQuery`

## Changes

- `frontend/src/pages/JourneysPage.tsx`:
  - Added `deletedJourneyIds` state
  - Added `journeyMonitors` computed property with local filtering
  - Updated `handleJourneyMonitorDelete` to use local state
  - Updated rendering to use filtered `journeyMonitors` array

## Result

- ✅ Deleted journey vanishes immediately from UI without backend refetch
- ✅ No unnecessary network requests
- ✅ E2E tested with Playwright MCP

## Related

- Follow-up to `3d4d0b2` (fix(frontend): refresh watchlist after delete, guard null profile picture URL)