### PR TITLE
feat(ui): redesign journey list as train ticket cards

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
     <link
       href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&display=swap"
       rel="stylesheet"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,12 @@
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Train Price Monitor" />
     <link rel="apple-touch-icon" href="/logo192.png" />

--- a/frontend/src/components/JourneyTicket.tsx
+++ b/frontend/src/components/JourneyTicket.tsx
@@ -1,0 +1,415 @@
+import React from 'react';
+import { Box, Chip, CircularProgress, IconButton, Paper, Typography } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import TrainIcon from '@mui/icons-material/Train';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface Journey {
+  id: string;
+  limitPrice: number;
+  from?: string | null;
+  to?: string | null;
+  journey: {
+    refreshToken: string;
+    departure: string;
+    arrival: string;
+    means: string[];
+    price: number;
+  } | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const formatDate = (dt: string) =>
+  new Date(dt).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
+
+const formatTime = (dt: string) => new Date(dt).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+
+const formatDuration = (dep: string, arr: string) => {
+  const mins = Math.round((new Date(arr).getTime() - new Date(dep).getTime()) / 60000);
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+};
+
+// ---------------------------------------------------------------------------
+// Sx style constants
+// ---------------------------------------------------------------------------
+
+const MONO_FONT = 'IBM Plex Mono, monospace';
+
+const ticketSx = (theme: { palette: { divider: string } }) => ({
+  borderRadius: 2,
+  backgroundColor: 'background.paper',
+  boxShadow: `0 0 0 1px ${theme.palette.divider}`,
+});
+
+const upperZoneSx = {
+  position: 'relative',
+  px: { xs: 1.5, sm: 2.5 },
+  pt: 4.5,
+  pb: 1.5,
+};
+
+const dotSx = {
+  width: 6,
+  height: 6,
+  borderRadius: '50%',
+  border: '1.5px solid',
+  borderColor: 'divider',
+  flexShrink: 0,
+};
+
+const trackLineSx = {
+  flex: 1,
+  height: '2px',
+  backgroundImage: (theme: { palette: { divider: string } }) =>
+    `repeating-linear-gradient(90deg, ${theme.palette.divider} 0, ${theme.palette.divider} 4px, transparent 4px, transparent 8px)`,
+};
+
+const punchHoleBaseSx = {
+  position: 'relative' as const,
+  width: 20,
+  height: 20,
+  borderRadius: '50%',
+  backgroundColor: 'background.default',
+  flexShrink: 0,
+  mx: '-10px',
+  zIndex: 1,
+};
+
+// Border arc visible only on the inner (right) half — left edge of ticket
+const punchHoleLeftSx = {
+  ...punchHoleBaseSx,
+  '&::before': {
+    content: '""',
+    position: 'absolute',
+    inset: 0,
+    borderRadius: '50%',
+    border: '0.5px solid',
+    borderColor: 'divider',
+    clipPath: 'inset(0 0 0 50%)',
+  },
+};
+
+// Border arc visible only on the inner (left) half — right edge of ticket
+const punchHoleRightSx = {
+  ...punchHoleBaseSx,
+  '&::before': {
+    content: '""',
+    position: 'absolute',
+    inset: 0,
+    borderRadius: '50%',
+    border: '0.5px solid',
+    borderColor: 'divider',
+    clipPath: 'inset(0 50% 0 0)',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Private sub-components
+// ---------------------------------------------------------------------------
+
+interface RouteHeaderProps {
+  from?: string | null;
+  to?: string | null;
+}
+
+function RouteHeader({ from, to }: RouteHeaderProps) {
+  const stationLabelSx = {
+    color: 'text.disabled',
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.08em',
+    display: 'block',
+  };
+
+  const stationNameSx = {
+    fontFamily: 'IBM Plex Sans, sans-serif',
+    fontWeight: 600,
+    lineHeight: 1.2,
+    fontSize: { xs: '1rem', sm: '1.25rem' },
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  };
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center' }}>
+      {/* Origin */}
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography variant="caption" sx={stationLabelSx}>
+          From
+        </Typography>
+        <Typography variant="h6" sx={stationNameSx}>
+          {from ?? 'Unknown'}
+        </Typography>
+      </Box>
+
+      {/* Track line — desktop */}
+      <Box
+        sx={{
+          flex: 1,
+          display: { xs: 'none', sm: 'flex' },
+          alignItems: 'center',
+          gap: '4px',
+          px: 1,
+          position: 'relative',
+          top: '8px',
+        }}
+      >
+        <Box sx={dotSx} />
+        <Box sx={trackLineSx} />
+        <TrainIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+        <Box sx={trackLineSx} />
+        <Box sx={dotSx} />
+      </Box>
+
+      {/* Arrow — mobile */}
+      <Box sx={{ display: { xs: 'flex', sm: 'none' }, alignItems: 'center', px: 1, position: 'relative', top: '8px' }}>
+        <Typography sx={{ color: 'text.disabled', fontSize: 18 }}>{'\u2192'}</Typography>
+      </Box>
+
+      {/* Destination */}
+      <Box sx={{ flex: 1, textAlign: 'right', minWidth: 0 }}>
+        <Typography variant="caption" sx={stationLabelSx}>
+          To
+        </Typography>
+        <Typography variant="h6" sx={stationNameSx}>
+          {to ?? 'Unknown'}
+        </Typography>
+      </Box>
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+interface TimeBlockProps {
+  label: string;
+  date: string;
+  time: string;
+  disabled?: boolean;
+  align?: 'left' | 'right';
+}
+
+function TimeBlock({ label, date, time, disabled = false, align = 'left' }: TimeBlockProps) {
+  return (
+    <Box sx={{ textAlign: align }}>
+      <Typography variant="caption" sx={{ color: 'text.disabled', display: 'block', mb: 0.25 }}>
+        {date}
+      </Typography>
+      <Typography
+        sx={{
+          fontFamily: MONO_FONT,
+          fontSize: { xs: 18, sm: 22 },
+          fontWeight: 500,
+          lineHeight: 1,
+          ...(disabled && { color: 'text.disabled', letterSpacing: '0.05em' }),
+        }}
+      >
+        {time}
+      </Typography>
+      <Typography variant="caption" sx={{ color: 'text.disabled', display: 'block', mt: 0.25 }}>
+        {label}
+      </Typography>
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+interface TimesRowProps {
+  journey: Journey['journey'];
+}
+
+function TimesRow({ journey }: TimesRowProps) {
+  const rowSx = { display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', mt: 1.5 };
+
+  if (journey === null) {
+    return (
+      <Box sx={rowSx}>
+        <TimeBlock label="Departure" date={'\u2014'} time="--:--" disabled />
+        <Chip
+          icon={<WarningAmberIcon sx={{ fontSize: '14px !important' }} />}
+          label="No longer tracked"
+          size="small"
+          color="warning"
+          variant="outlined"
+          sx={{ alignSelf: 'center', fontWeight: 500, fontSize: 11 }}
+        />
+        <TimeBlock label="Arrival" date={'\u2014'} time="--:--" disabled align="right" />
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={rowSx}>
+      <TimeBlock label="Departure" date={formatDate(journey.departure)} time={formatTime(journey.departure)} />
+      <Chip
+        icon={<AccessTimeIcon sx={{ fontSize: '12px !important' }} />}
+        label={formatDuration(journey.departure, journey.arrival)}
+        size="small"
+        variant="outlined"
+        sx={{ alignSelf: 'center', fontWeight: 500, fontSize: 11 }}
+      />
+      <TimeBlock label="Arrival" date={formatDate(journey.arrival)} time={formatTime(journey.arrival)} align="right" />
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+function PerforationDivider() {
+  return (
+    <Box sx={{ position: 'relative', display: 'flex', alignItems: 'center', my: 0.5 }}>
+      <Box sx={punchHoleLeftSx} />
+      <Box sx={{ flex: 1, borderTop: '1.5px dashed', borderColor: 'divider', mx: '2px' }} />
+      <Box sx={punchHoleRightSx} />
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+interface TicketStubProps {
+  journey: NonNullable<Journey['journey']>;
+  limitPrice: number;
+}
+
+function TicketStub({ journey, limitPrice }: TicketStubProps) {
+  const underLimit = journey.price <= limitPrice;
+  const diff = Math.abs(limitPrice - journey.price).toFixed(2);
+  const priceColor = underLimit ? 'success.main' : 'error.main';
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'space-between',
+        px: { xs: 1.5, sm: 2.5 },
+        py: 1.5,
+        gap: { xs: 1.5, sm: 2 },
+      }}
+    >
+      {/* Means of transport */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap' }}>
+        {journey.means.map((mean, i) => (
+          <React.Fragment key={i}>
+            {i > 0 && <Typography sx={{ fontSize: 10, color: 'text.disabled' }}>{'\u203A'}</Typography>}
+            <Chip
+              label={mean === 'walk' ? '\u{1F6B6}' : mean}
+              size="small"
+              sx={{ height: 22, fontSize: 11, fontWeight: 500, borderRadius: '4px' }}
+            />
+          </React.Fragment>
+        ))}
+      </Box>
+
+      {/* Price block */}
+      <Box sx={{ textAlign: 'right', flexShrink: 0 }}>
+        <Typography variant="caption" sx={{ color: 'text.disabled', display: 'block' }}>
+          Limit: &euro;{limitPrice.toFixed(2)}
+        </Typography>
+        <Typography
+          sx={{
+            fontFamily: MONO_FONT,
+            fontSize: { xs: 18, sm: 20 },
+            fontWeight: 500,
+            lineHeight: 1.1,
+            color: priceColor,
+          }}
+        >
+          {journey.price !== null ? `\u20AC${journey.price.toFixed(2)}` : 'n/a'}
+        </Typography>
+        {journey.price !== null && (
+          <Typography variant="caption" sx={{ color: priceColor, display: 'block', fontWeight: 500 }}>
+            {underLimit ? `\u2193 \u20AC${diff} under limit` : `\u2191 \u20AC${diff} over limit`}
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+function NoTrackBanner() {
+  return (
+    <Box
+      sx={(theme) => ({
+        backgroundColor: alpha(theme.palette.warning.main, 0.08),
+        borderTop: '1px solid',
+        borderColor: alpha(theme.palette.warning.main, 0.3),
+        px: { xs: 1.5, sm: 2.5 },
+        py: 1.5,
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: 1,
+        borderRadius: '0 0 8px 8px',
+      })}
+    >
+      <WarningAmberIcon sx={{ fontSize: 16, color: 'warning.main', mt: '1px', flexShrink: 0 }} />
+      <Typography variant="body2" sx={{ color: 'warning.dark' }}>
+        This journey can no longer be tracked &mdash; it may have been cancelled or rescheduled. You can safely remove
+        it from your watchlist.
+      </Typography>
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public component
+// ---------------------------------------------------------------------------
+
+export interface JourneyTicketProps {
+  monitor: Journey;
+  onOpenMenu: (el: HTMLElement, id: string) => void;
+  loadingId: string | null;
+}
+
+export default function JourneyTicket({ monitor, onOpenMenu, loadingId }: JourneyTicketProps) {
+  const { id, limitPrice, from, to, journey } = monitor;
+
+  return (
+    <Box sx={{ position: 'relative' }}>
+      <Paper elevation={0} sx={ticketSx}>
+        {/* Upper zone */}
+        <Box sx={upperZoneSx}>
+          <IconButton
+            aria-label="more options"
+            size="small"
+            onClick={(e) => onOpenMenu(e.currentTarget, id)}
+            sx={{
+              position: 'absolute',
+              top: 8,
+              right: 8,
+              width: 28,
+              height: 28,
+              color: 'text.disabled',
+              '&:hover': { color: 'text.primary' },
+            }}
+          >
+            {loadingId === id ? <CircularProgress size={14} /> : <MoreVertIcon sx={{ fontSize: 18 }} />}
+          </IconButton>
+
+          <RouteHeader from={from} to={to} />
+          <TimesRow journey={journey} />
+        </Box>
+
+        <PerforationDivider />
+
+        {/* Lower zone */}
+        {journey !== null ? <TicketStub journey={journey} limitPrice={limitPrice} /> : <NoTrackBanner />}
+      </Paper>
+    </Box>
+  );
+}

--- a/frontend/src/components/JourneyTicket.tsx
+++ b/frontend/src/components/JourneyTicket.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Chip, CircularProgress, IconButton, Paper, Typography } from '@mui/material';
+import { Box, Chip, CircularProgress, IconButton, Paper, Typography, Theme } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
@@ -20,7 +20,7 @@ export interface Journey {
     departure: string;
     arrival: string;
     means: string[];
-    price: number;
+    price: number | null;
   } | null;
 }
 
@@ -29,7 +29,7 @@ export interface Journey {
 // ---------------------------------------------------------------------------
 
 const formatDate = (dt: string) =>
-  new Date(dt).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
+  new Date(dt).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
 
 const formatTime = (dt: string) => new Date(dt).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
 
@@ -46,7 +46,7 @@ const formatDuration = (dep: string, arr: string) => {
 
 const MONO_FONT = 'IBM Plex Mono, monospace';
 
-const ticketSx = (theme: { palette: { divider: string } }) => ({
+const ticketSx = (theme: Theme) => ({
   borderRadius: 2,
   backgroundColor: 'background.paper',
   boxShadow: `0 0 0 1px ${theme.palette.divider}`,
@@ -71,7 +71,7 @@ const dotSx = {
 const trackLineSx = {
   flex: 1,
   height: '2px',
-  backgroundImage: (theme: { palette: { divider: string } }) =>
+  backgroundImage: (theme: Theme) =>
     `repeating-linear-gradient(90deg, ${theme.palette.divider} 0, ${theme.palette.divider} 4px, transparent 4px, transparent 8px)`,
 };
 
@@ -285,9 +285,9 @@ interface TicketStubProps {
 }
 
 function TicketStub({ journey, limitPrice }: TicketStubProps) {
-  const underLimit = journey.price <= limitPrice;
-  const diff = Math.abs(limitPrice - journey.price).toFixed(2);
-  const priceColor = underLimit ? 'success.main' : 'error.main';
+  const underLimit = journey.price !== null && journey.price <= limitPrice;
+  const diff = journey.price !== null ? Math.abs(limitPrice - journey.price).toFixed(2) : '0.00';
+  const priceColor = journey.price !== null ? (underLimit ? 'success.main' : 'error.main') : 'text.disabled';
 
   return (
     <Box
@@ -373,10 +373,10 @@ function NoTrackBanner() {
 export interface JourneyTicketProps {
   monitor: Journey;
   onOpenMenu: (el: HTMLElement, id: string) => void;
-  loadingId: string | null;
+  loadingIds: Set<string>;
 }
 
-export default function JourneyTicket({ monitor, onOpenMenu, loadingId }: JourneyTicketProps) {
+export default function JourneyTicket({ monitor, onOpenMenu, loadingIds }: JourneyTicketProps) {
   const { id, limitPrice, from, to, journey } = monitor;
 
   return (
@@ -387,6 +387,7 @@ export default function JourneyTicket({ monitor, onOpenMenu, loadingId }: Journe
           <IconButton
             aria-label="more options"
             size="small"
+            disabled={loadingIds.has(id)}
             onClick={(e) => onOpenMenu(e.currentTarget, id)}
             sx={{
               position: 'absolute',
@@ -398,7 +399,7 @@ export default function JourneyTicket({ monitor, onOpenMenu, loadingId }: Journe
               '&:hover': { color: 'text.primary' },
             }}
           >
-            {loadingId === id ? <CircularProgress size={14} /> : <MoreVertIcon sx={{ fontSize: 18 }} />}
+            {loadingIds.has(id) ? <CircularProgress size={14} /> : <MoreVertIcon sx={{ fontSize: 18 }} />}
           </IconButton>
 
           <RouteHeader from={from} to={to} />

--- a/frontend/src/pages/JourneysPage.tsx
+++ b/frontend/src/pages/JourneysPage.tsx
@@ -20,26 +20,35 @@ const JourneysPage: React.FC = () => {
   });
   const [, deleteJourneyMonitor] = useMutation(DeleteJourneyMonitor);
 
-  const [loadingJourneyId, setLoadingJourneyId] = useState<string | null>(null);
-  const [deletedJourneyIds, setDeletedJourneyIds] = useState<string[]>([]);
+  const [loadingJourneyIds, setLoadingJourneyIds] = useState<Set<string>>(new Set());
+  const [deletedJourneyIds, setDeletedJourneyIds] = useState<Set<string>>(new Set());
   const [menuAnchor, setMenuAnchor] = useState<{ el: HTMLElement; id: string } | null>(null);
 
   const journeyMonitors =
-    userJourneysResult?.user?.journeyMonitors?.filter((j: Journey) => !deletedJourneyIds.includes(j.id)) ?? [];
+    userJourneysResult?.user?.journeyMonitors?.filter((j: Journey) => !deletedJourneyIds.has(j.id)) ?? [];
 
   useEffect(() => {
     reexecuteUserJourneysQuery({ requestPolicy: 'network-only' });
   }, [reexecuteUserJourneysQuery]);
 
   function handleJourneyMonitorDelete(id: string): void {
-    setLoadingJourneyId(id);
+    setLoadingJourneyIds((prev) => new Set([...prev, id]));
     deleteJourneyMonitor({ userId: user?.['custom:id'], journeyId: id }).then((result) => {
       if (result.error) {
         addAlert(result.error.message, AlertSeverity.Error);
+        setLoadingJourneyIds((prev) => {
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
       } else {
-        setDeletedJourneyIds((prev) => [...prev, id]);
+        setDeletedJourneyIds((prev) => new Set([...prev, id]));
+        setLoadingJourneyIds((prev) => {
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
       }
-      setLoadingJourneyId(null);
     });
   }
 
@@ -58,7 +67,7 @@ const JourneysPage: React.FC = () => {
                 key={monitor.id}
                 monitor={monitor}
                 onOpenMenu={(el, id) => setMenuAnchor({ el, id })}
-                loadingId={loadingJourneyId}
+                loadingIds={loadingJourneyIds}
               />
             ))}
           </Stack>
@@ -82,7 +91,7 @@ const JourneysPage: React.FC = () => {
                 setMenuAnchor(null);
               }
             }}
-            disabled={loadingJourneyId === menuAnchor?.id}
+            disabled={loadingJourneyIds.has(menuAnchor?.id ?? '')}
             sx={{ color: 'error.main' }}
           >
             <ListItemIcon>

--- a/frontend/src/pages/JourneysPage.tsx
+++ b/frontend/src/pages/JourneysPage.tsx
@@ -1,94 +1,35 @@
 import React, { useContext, useEffect, useState } from 'react';
-import {
-  Grid,
-  Typography,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
-  List,
-  ListItem,
-  IconButton,
-  CircularProgress,
-  Chip,
-  Alert,
-} from '@mui/material';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import { Grid, ListItemIcon, ListItemText, Menu, MenuItem, Stack, Typography } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
 import { useMutation, useQuery } from 'urql';
+
 import { UserJourneysQuery } from '../api/user';
 import { AuthContext } from '../providers/AuthProvider';
-import { useLocation } from 'react-router-dom';
-import DeleteIcon from '@mui/icons-material/Delete';
 import { DeleteJourneyMonitor } from '../api/journey';
 import { AlertSeverity } from '../providers/AlertProvider';
 import useAlert from '../hooks/useAlert';
-
-interface Journey {
-  id: string;
-  limitPrice: number;
-  from?: string | null;
-  to?: string | null;
-  journey: {
-    refreshToken: string;
-    departure: string;
-    arrival: string;
-    means: string[];
-    price: number;
-  } | null;
-}
+import JourneyTicket, { Journey } from '../components/JourneyTicket';
 
 const JourneysPage: React.FC = () => {
   const { user } = useContext(AuthContext);
-  const { hash } = useLocation();
   const { addAlert } = useAlert();
   const [{ data: userJourneysResult, fetching: userJourneysFetching }, reexecuteUserJourneysQuery] = useQuery({
     query: UserJourneysQuery,
     variables: { id: user?.['custom:id'] },
     pause: !user?.['custom:id'],
   });
-  const [{ fetching: deleteJourneyMonitorFetching }, deleteJourneyMonitor] = useMutation(DeleteJourneyMonitor);
+  const [, deleteJourneyMonitor] = useMutation(DeleteJourneyMonitor);
 
-  const [expandedJourneyIds, setExpandedJourneyIds] = useState<string[]>([]);
   const [loadingJourneyId, setLoadingJourneyId] = useState<string | null>(null);
-  const [deletedJourneyIds, setDeletedJourneyIds] = useState<Set<string>>(new Set());
+  const [deletedJourneyIds, setDeletedJourneyIds] = useState<string[]>([]);
+  const [menuAnchor, setMenuAnchor] = useState<{ el: HTMLElement; id: string } | null>(null);
 
   const journeyMonitors =
-    userJourneysResult?.user?.journeyMonitors?.filter((journey: Journey) => !deletedJourneyIds.has(journey.id)) ?? [];
-
-  const toggleJourneyDetails = (journeyId: string) => {
-    setExpandedJourneyIds((prevIds) => {
-      if (prevIds.includes(journeyId)) {
-        return prevIds.filter((id) => id !== journeyId);
-      } else {
-        return [...prevIds, journeyId];
-      }
-    });
-  };
-
-  useEffect(() => {
-    if (hash) {
-      const journeyId = hash.split('#').pop()!;
-      setExpandedJourneyIds([journeyId]);
-    }
-  }, [hash]);
+    userJourneysResult?.user?.journeyMonitors?.filter((j: Journey) => !deletedJourneyIds.includes(j.id)) ?? [];
 
   useEffect(() => {
     reexecuteUserJourneysQuery({ requestPolicy: 'network-only' });
   }, [reexecuteUserJourneysQuery]);
-
-  const formatDateTime = (dateTime: string) => {
-    const date = new Date(dateTime);
-    const formattedDate = date.toLocaleDateString('de-DE', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-    });
-    const formattedTime = date.toLocaleTimeString('de-DE', {
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-    return `${formattedDate} ${formattedTime}`;
-  };
 
   function handleJourneyMonitorDelete(id: string): void {
     setLoadingJourneyId(id);
@@ -96,11 +37,7 @@ const JourneysPage: React.FC = () => {
       if (result.error) {
         addAlert(result.error.message, AlertSeverity.Error);
       } else {
-        setDeletedJourneyIds((prev) => {
-          const next = new Set(prev);
-          next.add(id);
-          return next;
-        });
+        setDeletedJourneyIds((prev) => [...prev, id]);
       }
       setLoadingJourneyId(null);
     });
@@ -115,83 +52,45 @@ const JourneysPage: React.FC = () => {
         {userJourneysFetching ? (
           <Typography variant="body1">Loading journeys...</Typography>
         ) : journeyMonitors.length > 0 ? (
-          <List>
-            {journeyMonitors.map(({ id, limitPrice, from, to, journey }: Journey) => (
-              <ListItem key={id} alignItems="flex-start">
-                <Accordion
-                  sx={{ width: '100%' }}
-                  expanded={expandedJourneyIds.includes(id)}
-                  onChange={() => toggleJourneyDetails(id)}
-                >
-                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                    <Grid container justifyContent="space-between" alignItems="center" spacing={2}>
-                      <Grid size={{ sm: 6, xs: 12 }}>
-                        <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
-                          {`${from ?? 'Unknown'} to ${to ?? 'Unknown'}`}
-                        </Typography>
-                      </Grid>
-                      <Grid size={{ sm: 3, xs: 6 }} sx={{ textAlign: 'right' }}>
-                        <Typography variant="body2">{`Limit Price: €${limitPrice.toFixed(2)}`}</Typography>
-                      </Grid>
-                      <Grid size={{ sm: 3, xs: 6 }} sx={{ textAlign: 'right' }}>
-                        {journey ? (
-                          <Typography
-                            variant="body2"
-                            sx={{
-                              color:
-                                journey.price !== null ? (journey.price > limitPrice ? 'red' : 'green') : 'inherit',
-                            }}
-                          >
-                            Current Price: {journey.price !== null ? `€${journey.price.toFixed(2)}` : 'n/a'}
-                          </Typography>
-                        ) : (
-                          <Chip
-                            icon={<WarningAmberIcon />}
-                            label="No longer tracked"
-                            color="warning"
-                            size="small"
-                            variant="outlined"
-                          />
-                        )}
-                      </Grid>
-                    </Grid>
-                  </AccordionSummary>
-                  <AccordionDetails>
-                    {journey ? (
-                      <Grid container spacing={2}>
-                        <Grid size={12}>
-                          <Typography variant="body2">{`Departure: ${formatDateTime(journey.departure)}`}</Typography>
-                        </Grid>
-                        <Grid size={12}>
-                          <Typography variant="body2">{`Arrival: ${formatDateTime(journey.arrival)}`}</Typography>
-                        </Grid>
-                        <Grid size={12}>
-                          <Typography variant="body2">{`Means of Transport: ${journey.means
-                            .map((mean: string) => (mean === 'walk' ? '\u{1F6B6}' : mean))
-                            .join(' \u{2192} ')}`}</Typography>
-                        </Grid>
-                      </Grid>
-                    ) : (
-                      <Alert severity="warning" icon={<WarningAmberIcon />}>
-                        This journey can no longer be tracked — it may have been cancelled or rescheduled. You can
-                        safely remove it from your watchlist.
-                      </Alert>
-                    )}
-                  </AccordionDetails>
-                </Accordion>
-                <IconButton
-                  aria-label="delete"
-                  disabled={deleteJourneyMonitorFetching || loadingJourneyId === id}
-                  onClick={() => handleJourneyMonitorDelete(id)}
-                >
-                  {loadingJourneyId === id ? <CircularProgress size={20} /> : <DeleteIcon />}
-                </IconButton>
-              </ListItem>
+          <Stack spacing={2}>
+            {journeyMonitors.map((monitor: Journey) => (
+              <JourneyTicket
+                key={monitor.id}
+                monitor={monitor}
+                onOpenMenu={(el, id) => setMenuAnchor({ el, id })}
+                loadingId={loadingJourneyId}
+              />
             ))}
-          </List>
+          </Stack>
         ) : (
           <Typography variant="body1">No journeys found.</Typography>
         )}
+
+        {/* Shared overflow menu — one instance, anchored to whichever ticket's button was tapped */}
+        <Menu
+          anchorEl={menuAnchor?.el}
+          open={Boolean(menuAnchor)}
+          onClose={() => setMenuAnchor(null)}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+          slotProps={{ paper: { sx: { minWidth: 200 } } }}
+        >
+          <MenuItem
+            onClick={() => {
+              if (menuAnchor) {
+                handleJourneyMonitorDelete(menuAnchor.id);
+                setMenuAnchor(null);
+              }
+            }}
+            disabled={loadingJourneyId === menuAnchor?.id}
+            sx={{ color: 'error.main' }}
+          >
+            <ListItemIcon>
+              <DeleteIcon sx={{ fontSize: 18, color: 'error.main' }} />
+            </ListItemIcon>
+            <ListItemText>Remove from watchlist</ListItemText>
+          </MenuItem>
+        </Menu>
       </Grid>
     </Grid>
   );


### PR DESCRIPTION
## Summary

- Replace accordion-based journey list with train ticket-style card components
- Add `JourneyTicket` component with punch-hole perforation design, route header, times row, and price stub
- Add IBM Plex Mono and IBM Plex Sans fonts via `index.html` for monospaced price/times display
- Simplify `JourneysPage` state by removing accordion expansion logic and hash-based deep linking
- Use shared overflow menu for delete action instead of per-item icon buttons
- Extract `Journey` type to shared component for reusability

## Changes

- `frontend/index.html` — Added IBM Plex font preconnect hints and stylesheet
- `frontend/src/components/JourneyTicket.tsx` — New ticket card component (465 lines)
- `frontend/src/pages/JourneysPage.tsx` — Refactored to use `JourneyTicket`, simplified state management