### PR TITLE
chore(deps): update prettier, eslint, and uuid dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,18 +14,18 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 'v3.1.0'
+  - repo: https://github.com/34j/mirrors-prettier
+    rev: 'v3.8.3'
     hooks:
       - id: prettier
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: 'v10.2.0'
+    rev: 'v10.4.0'
     hooks:
       - id: eslint
         args: ['--max-warnings=0', '--config', 'eslint.config.cjs']
         additional_dependencies:
-          - 'eslint@10.2.0'
+          - 'eslint@10.4.0'
           - '@typescript-eslint/eslint-plugin@8.58.2'
           - '@typescript-eslint/parser@8.58.2'
           - 'typescript@5.9.3'

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -30,7 +30,7 @@
         "graphql-scalars": "^1.25.0",
         "graphql-yoga": "^5.18.1",
         "morgan": "^1.10.0",
-        "uuid": "^11.1.1"
+        "uuid": "^14.0.0"
       },
       "devDependencies": {
         "@graphql-codegen/cli": "^6.2.1",
@@ -6401,6 +6401,19 @@
         "url": "https://github.com/sponsors/derhuerst"
       }
     },
+    "node_modules/db-vendo-client/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/debounce": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
@@ -10327,16 +10340,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -55,6 +55,6 @@
     "graphql-scalars": "^1.25.0",
     "graphql-yoga": "^5.18.1",
     "morgan": "^1.10.0",
-    "uuid": "^11.1.1"
+    "uuid": "^14.0.0"
   }
 }

--- a/backend/src/resolvers/user.ts
+++ b/backend/src/resolvers/user.ts
@@ -508,7 +508,7 @@ export async function getJourneyMonitor(
     limitPrice: dbJourney.limitPrice,
     expires: dbJourney.expires,
     from: journey?.legs[0].origin?.name ?? undefined,
-    to: journey ? journey.legs[journey.legs.length - 1].destination?.name ?? undefined : undefined,
+    to: journey ? (journey.legs[journey.legs.length - 1].destination?.name ?? undefined) : undefined,
     firstClass: dbJourney.firstClass ?? undefined,
     bike: dbJourney.bike ?? undefined,
     deutschlandTicketDiscount: dbJourney.deutschlandTicketDiscount ?? undefined,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,7 +9,7 @@
       href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&display=swap"
       rel="stylesheet"
       media="print"
-      onload="this.media='all'"
+      onload="this.media = 'all'"
     />
     <noscript>
       <link

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,7 +23,7 @@
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.0.0",
         "urql": "^5.0.1",
-        "uuid": "^9.0.0"
+        "uuid": "^14.0.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -6259,11 +6259,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -10659,9 +10664,9 @@
       }
     },
     "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="
     },
     "vite": {
       "version": "8.0.11",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.0.0",
     "urql": "^5.0.1",
-    "uuid": "^9.0.0"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/frontend/src/components/JourneyTicket.tsx
+++ b/frontend/src/components/JourneyTicket.tsx
@@ -312,7 +312,7 @@ function TicketStub({
 
   // Build options pills
   const ageGroupLabel =
-    ageGroup && ageGroup !== 'ADULT' ? AGE_GROUP_OPTIONS.find((o) => o.value === ageGroup)?.label ?? ageGroup : null;
+    ageGroup && ageGroup !== 'ADULT' ? (AGE_GROUP_OPTIONS.find((o) => o.value === ageGroup)?.label ?? ageGroup) : null;
 
   const neutralPillSx = (theme: Theme) => ({
     height: 20,

--- a/frontend/src/components/SearchMask.tsx
+++ b/frontend/src/components/SearchMask.tsx
@@ -351,7 +351,7 @@ const SearchMask: React.FC<Props> = ({
 
   const handleLoyaltyCardChange = (e: SelectChangeEvent<string>) => {
     const key = e.target.value;
-    setLoyaltyCard(key ? keyToCard(key) ?? null : null);
+    setLoyaltyCard(key ? (keyToCard(key) ?? null) : null);
   };
 
   const optionsActive =


### PR DESCRIPTION
## Summary

Update several project dependencies — prettier (with a working pre-commit mirror), eslint, and uuid in both backend and frontend — to latest stable versions.

## Changes

- **pre-commit**: Replace archived `pre-commit/mirrors-prettier` with community-maintained `34j/mirrors-prettier` (v3.1.0 → v3.8.3) to restore pre-commit compatibility for prettier
- **pre-commit**: Update `pre-commit/mirrors-eslint` to v10.4.0 with matching `additional_dependencies`
- **backend**: Bump `uuid` ^11.1.1 → ^14.0.0 (includes security fix for GHSA-w5hq-g745-h8pq)
- **frontend**: Bump `uuid` ^9.0.0 → ^14.0.0 (same security fix)
- **formatting**: Apply prettier v3.8.3 formatting to source files

## Verification

- TypeScript typecheck passes for both backend and frontend
- ESLint lint passes for both modules
- Pre-commit hooks (including prettier v3.8.3) pass on commit
