### PR TITLE
fix(backend): bundle uuid v14 to prevent ESM Lambda crash

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
     "codegen": "graphql-codegen --config src/codegen.yml",
     "dev": "cross-env NODE_ENV=development ts-node-dev --exit-child --respawn src/main.ts",
     "start": "ts-node src/main.ts",
-    "build": "esbuild src/main.ts --bundle --minify --sourcemap --platform=node --target=es2020 --format=cjs --external:cross-fetch --external:db-hafas-stations --external:gps-distance --external:https-proxy-agent --external:luxon --external:qs --external:slugg --external:uuid --outfile=dist/main.js",
+    "build": "esbuild src/main.ts --bundle --minify --sourcemap --platform=node --target=es2020 --format=cjs --external:cross-fetch --external:db-hafas-stations --external:gps-distance --external:https-proxy-agent --external:luxon --external:qs --external:slugg --outfile=dist/main.js",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/"
   },


### PR DESCRIPTION
## Summary

Removes `uuid` from the esbuild `--external` list so it gets bundled into the Lambda artifact. `uuid` v14 is ESM-only and cannot be `require()`d at runtime, causing a `UserCodeSyntaxError` cold-start crash that surfaces as a 502 from API Gateway.

## Changes

**`backend/package.json`**
- Removed `--external:uuid` from the `build` script's esbuild flags so `uuid` is bundled (transpiled to CJS) rather than left as an external `require()` call at runtime.

This follows the same pattern already established in `AGENTS.md` for `db-vendo-client`: ESM-only packages must be bundled, not externalized, when the Lambda output format is `--format=cjs`.

## Verification

- TypeScript and ESLint checks pass (`npm run typecheck && npm run lint` in `backend/`)
- Build produces a valid CJS bundle (`npm run build` in `backend/`)
- Lambda no longer crashes on cold start; API Gateway no longer returns 502
