### PR TITLE
fix(backend): recover stale HAFAS refresh tokens on watchlist load

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -22,7 +22,7 @@
         "cors": "^2.8.5",
         "cross-fetch": "^4.0.0",
         "db-hafas-stations": "^2.0.0",
-        "db-vendo-client": "^6.10.8",
+        "db-vendo-client": "^6.10.11",
         "dotenv": "^16.4.5",
         "dynamodb-toolbox": "^2.0.0",
         "express": "^4.21.2",
@@ -6379,9 +6379,9 @@
       }
     },
     "node_modules/db-vendo-client": {
-      "version": "6.10.8",
-      "resolved": "https://registry.npmjs.org/db-vendo-client/-/db-vendo-client-6.10.8.tgz",
-      "integrity": "sha512-MrARSEhIhNca2dTBPrAUW5E5TX2plJLfcJTfKcbsCcAXH+glDjNWf2IWb7kJybSxYxELdJAWBR5DYO0+HjC7Og==",
+      "version": "6.10.11",
+      "resolved": "https://registry.npmjs.org/db-vendo-client/-/db-vendo-client-6.10.11.tgz",
+      "integrity": "sha512-Q4qibNt+1Y5/JUIS4Iboof1tNXN+8K0tAoeCLlVUdTbcYgtwVUjQPVPdsxbSY9M/S54KSrew9dvlaYhItyiagg==",
       "license": "ISC",
       "dependencies": {
         "content-type": "^1.0.5",

--- a/backend/package.json
+++ b/backend/package.json
@@ -47,7 +47,7 @@
     "cors": "^2.8.5",
     "cross-fetch": "^4.0.0",
     "db-hafas-stations": "^2.0.0",
-    "db-vendo-client": "^6.10.8",
+    "db-vendo-client": "^6.10.11",
     "dotenv": "^16.4.5",
     "dynamodb-toolbox": "^2.0.0",
     "express": "^4.21.2",

--- a/backend/src/managers/DbHafasManager.ts
+++ b/backend/src/managers/DbHafasManager.ts
@@ -1,6 +1,8 @@
 import type { HafasClient, Journey, JourneyWithRealtimeData, Journeys, Station } from 'hafas-client';
 import { createClient } from 'db-vendo-client';
 import { profile as dbProfile } from 'db-vendo-client/p/dbweb/index.js';
+import { parseJourneyLeg as originalParseJourneyLeg } from 'db-vendo-client/parse/journey-leg.js';
+import { parseStopover as originalParseStopover } from 'db-vendo-client/parse/stopover.js';
 import Logger from '../lib/logger';
 import { LoyaltyCardData, toHafasLoyaltyCard, toHafasAgeGroup } from '../lib/loyaltyCards';
 
@@ -9,6 +11,49 @@ interface SimpleStation {
   id: string;
   name: string;
   weight: number;
+}
+
+/**
+ * The dbweb /angebote/recon endpoint returns departure/arrival times as nested objects:
+ *   { abfahrt: { sollzeit: "2026-05-25T18:36:00", istzeit: "..." }, ... }
+ * But the db-vendo-client parser expects flat string fields:
+ *   { abfahrtsZeitpunkt: "2026-05-25T18:36:00", ezAbfahrtsZeitpunkt: "...", ... }
+ *
+ * This normalizer maps the nested format to the flat format so the parser can extract times.
+ * See: https://github.com/public-transport/db-vendo-client/blob/main/parse/journey-leg.js
+ */
+interface TimeFields {
+  sollzeit?: string;
+  istzeit?: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function normalizeStopTimes(obj: Record<string, any>): void {
+  const abfahrt = obj.abfahrt as TimeFields | undefined;
+  const ankunft = obj.ankunft as TimeFields | undefined;
+
+  if (!obj.abfahrtsZeitpunkt && !obj.abgangsDatum && abfahrt?.sollzeit) {
+    obj.abgangsDatum = abfahrt.sollzeit;
+  }
+  if (!obj.ezAbfahrtsZeitpunkt && !obj.ezAbgangsDatum && abfahrt?.istzeit) {
+    obj.ezAbgangsDatum = abfahrt.istzeit;
+  }
+  if (!obj.ankunftsZeitpunkt && !obj.ankunftsDatum && ankunft?.sollzeit) {
+    obj.ankunftsDatum = ankunft.sollzeit;
+  }
+  if (!obj.ezAnkunftsZeitpunkt && !obj.ezAnkunftsDatum && ankunft?.istzeit) {
+    obj.ezAnkunftsDatum = ankunft.istzeit;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function normalizeLegTimes(pt: Record<string, any>): void {
+  normalizeStopTimes(pt);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const stops = (pt.halte || pt.stops || []) as Record<string, any>[];
+  for (const stop of stops) {
+    normalizeStopTimes(stop);
+  }
 }
 
 export interface PricingOptions {
@@ -96,6 +141,26 @@ function buildHafasOptions(pricingOptions?: PricingOptions): Record<string, unkn
 const userAgent = 'https://github.com/wolfm89/train-price-monitor';
 
 /**
+ * Custom dbweb profile that normalizes /angebote/recon response times.
+ * Wraps parseJourneyLeg and parseStopover to map nested time objects
+ * (abfahrt.sollzeit / ankunft.sollzeit) to flat fields expected by the parser.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const customDbProfile: any = {
+  ...dbProfile,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  parseJourneyLeg: (ctx: any, pt: any, date: any, fallbackLocations: any) => {
+    normalizeLegTimes(pt);
+    return originalParseJourneyLeg(ctx, pt, date, fallbackLocations);
+  },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  parseStopover: (ctx: any, st: any, date: any) => {
+    normalizeStopTimes(st);
+    return originalParseStopover(ctx, st, date);
+  },
+};
+
+/**
  * Manages interactions with the Hafas API for Deutsche Bahn operations.
  */
 export class DbHafasManager {
@@ -105,7 +170,7 @@ export class DbHafasManager {
    * Constructs a new DbHafasManager instance.
    */
   constructor() {
-    this.client = createClient(dbProfile, userAgent, { enrichStations: false });
+    this.client = createClient(customDbProfile, userAgent, { enrichStations: false });
   }
 
   /**

--- a/backend/src/managers/DbHafasManager.ts
+++ b/backend/src/managers/DbHafasManager.ts
@@ -1,6 +1,6 @@
 import type { HafasClient, Journey, JourneyWithRealtimeData, Journeys, Station } from 'hafas-client';
 import { createClient } from 'db-vendo-client';
-import { profile as dbProfile } from 'db-vendo-client/p/db/index.js';
+import { profile as dbProfile } from 'db-vendo-client/p/dbweb/index.js';
 import Logger from '../lib/logger';
 import { LoyaltyCardData, toHafasLoyaltyCard, toHafasAgeGroup } from '../lib/loyaltyCards';
 

--- a/backend/src/managers/DbHafasManager.ts
+++ b/backend/src/managers/DbHafasManager.ts
@@ -16,10 +16,12 @@ interface SimpleStation {
 /**
  * The dbweb /angebote/recon endpoint returns departure/arrival times as nested objects:
  *   { abfahrt: { sollzeit: "2026-05-25T18:36:00", istzeit: "..." }, ... }
- * But the db-vendo-client parser expects flat string fields:
- *   { abfahrtsZeitpunkt: "2026-05-25T18:36:00", ezAbfahrtsZeitpunkt: "...", ... }
+ * But the db-vendo-client parser expects flat string fields. It accepts either the older
+ * `abfahrtsZeitpunkt`/`ezAbfahrtsZeitpunkt` names or the newer `abgangsDatum`/`ezAbgangsDatum`
+ * names (via `||` fallback). This normalizer sets the newer names:
+ *   { abgangsDatum: "2026-05-25T18:36:00", ezAbgangsDatum: "...",
+ *     ankunftsDatum: "2026-05-25T20:10:00", ezAnkunftsDatum: "..." }
  *
- * This normalizer maps the nested format to the flat format so the parser can extract times.
  * See: https://github.com/public-transport/db-vendo-client/blob/main/parse/journey-leg.js
  */
 interface TimeFields {
@@ -145,17 +147,19 @@ const userAgent = 'https://github.com/wolfm89/train-price-monitor';
  * Wraps parseJourneyLeg and parseStopover to map nested time objects
  * (abfahrt.sollzeit / ankunft.sollzeit) to flat fields expected by the parser.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const customDbProfile: any = {
+const customDbProfile: typeof dbProfile & {
+  parseJourneyLeg: typeof originalParseJourneyLeg;
+  parseStopover: typeof originalParseStopover;
+} = {
   ...dbProfile,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  parseJourneyLeg: (ctx: any, pt: any, date: any, fallbackLocations: any) => {
-    normalizeLegTimes(pt);
+  parseJourneyLeg: (ctx, pt, date, fallbackLocations) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    normalizeLegTimes(pt as Record<string, any>);
     return originalParseJourneyLeg(ctx, pt, date, fallbackLocations);
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  parseStopover: (ctx: any, st: any, date: any) => {
-    normalizeStopTimes(st);
+  parseStopover: (ctx, st, date) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    normalizeStopTimes(st as Record<string, any>);
     return originalParseStopover(ctx, st, date);
   },
 };

--- a/backend/src/resolvers/user.ts
+++ b/backend/src/resolvers/user.ts
@@ -1,5 +1,5 @@
 import dotenv from 'dotenv'; // Load environment variables from .env file
-import { Journey as HafasJourney } from 'hafas-client';
+import type { Journey as HafasJourney } from 'hafas-client';
 import { GraphQLContext } from '../context';
 import {
   GetItemCommand,
@@ -105,7 +105,7 @@ export const userResolvers: UserResolvers = {
       (n: { read?: boolean }) => args.read === undefined || n.read === args.read
     );
 
-    const notifications = await Promise.all(
+    const notificationResults = await Promise.allSettled(
       filteredNotifications.map(
         async (dbNotification: {
           id: string;
@@ -141,6 +141,22 @@ export const userResolvers: UserResolvers = {
         }
       )
     );
+
+    const notifications = notificationResults
+      .filter(
+        (
+          result
+        ): result is PromiseFulfilledResult<
+          JourneyExpiryNotification | JourneyStaleNotification | PriceAlertNotification
+        > => {
+          if (result.status === 'rejected') {
+            Logger.error(`Failed to load notification: ${result.reason}`);
+            return false;
+          }
+          return true;
+        }
+      )
+      .map((result) => result.value);
 
     sort(notifications, '-timestamp');
     const limit = args.limit ?? undefined;
@@ -510,7 +526,7 @@ export async function getJourneyMonitor(
   try {
     hafasJourney = await context.dbHafas.requeryJourney(dbJourney.refreshToken, storedPricingOptions);
   } catch (error) {
-    Logger.warn(`Refresh token stale for journey ${dbJourney.id}, attempting recovery: ${error}`);
+    Logger.warn(`requeryJourney failed for journey ${dbJourney.id}, attempting recovery: ${error}`);
   }
 
   if (!hafasJourney) {

--- a/backend/src/resolvers/user.ts
+++ b/backend/src/resolvers/user.ts
@@ -142,21 +142,21 @@ export const userResolvers: UserResolvers = {
       )
     );
 
-    const notifications = notificationResults
-      .filter(
-        (
-          result
-        ): result is PromiseFulfilledResult<
-          JourneyExpiryNotification | JourneyStaleNotification | PriceAlertNotification
-        > => {
-          if (result.status === 'rejected') {
-            Logger.error(`Failed to load notification: ${result.reason}`);
-            return false;
-          }
-          return true;
+    const notifications = notificationResults.flatMap(
+      (result, index): (JourneyExpiryNotification | JourneyStaleNotification | PriceAlertNotification)[] => {
+        if (result.status === 'rejected') {
+          const n = filteredNotifications[index];
+          Logger.error('Failed to load notification', {
+            error: result.reason,
+            notificationId: n.id,
+            notificationType: n.type,
+            userId: n.userId,
+          });
+          return [];
         }
-      )
-      .map((result) => result.value);
+        return [result.value];
+      }
+    );
 
     sort(notifications, '-timestamp');
     const limit = args.limit ?? undefined;
@@ -526,7 +526,7 @@ export async function getJourneyMonitor(
   try {
     hafasJourney = await context.dbHafas.requeryJourney(dbJourney.refreshToken, storedPricingOptions);
   } catch (error) {
-    Logger.warn(`requeryJourney failed for journey ${dbJourney.id}, attempting recovery: ${error}`);
+    Logger.warn('requeryJourney failed, attempting recovery', { journeyId: dbJourney.id, error });
   }
 
   if (!hafasJourney) {

--- a/backend/src/resolvers/user.ts
+++ b/backend/src/resolvers/user.ts
@@ -1,4 +1,5 @@
 import dotenv from 'dotenv'; // Load environment variables from .env file
+import { Journey as HafasJourney } from 'hafas-client';
 import { GraphQLContext } from '../context';
 import {
   GetItemCommand,
@@ -168,6 +169,7 @@ export const userResolvers: UserResolvers = {
           id: string;
           fromId: string;
           toId: string;
+          departure: string;
           firstClass?: boolean;
           bike?: boolean;
           loyaltyCard?: string;
@@ -493,6 +495,7 @@ export async function getJourneyMonitor(
     id: string;
     fromId: string;
     toId: string;
+    departure: string;
     firstClass?: boolean;
     bike?: boolean;
     loyaltyCard?: string;
@@ -501,27 +504,76 @@ export async function getJourneyMonitor(
   }
 ): Promise<JourneyMonitor> {
   const storedPricingOptions = loadStoredPricingOptions(dbJourney);
-  const journey = await context.dbHafas.requeryJourney(dbJourney.refreshToken, storedPricingOptions);
+
+  let hafasJourney: HafasJourney | undefined;
+
+  try {
+    hafasJourney = await context.dbHafas.requeryJourney(dbJourney.refreshToken, storedPricingOptions);
+  } catch (error) {
+    Logger.warn(`Refresh token stale for journey ${dbJourney.id}, attempting recovery: ${error}`);
+  }
+
+  if (!hafasJourney) {
+    // Recovery: re-query by stored station IDs and departure time.
+    // Uses the same matching algorithm as the SQS updateJourneyMonitor path.
+    const departure = new Date(dbJourney.departure);
+
+    try {
+      const result = await context.dbHafas.queryJourneys(dbJourney.fromId, dbJourney.toId, departure, {
+        results: 5,
+        ...storedPricingOptions,
+      });
+
+      const candidates = result.journeys?.filter(
+        (j) =>
+          j.legs[0]?.origin?.id === dbJourney.fromId && j.legs[j.legs.length - 1]?.destination?.id === dbJourney.toId
+      );
+
+      const matchingJourney = candidates?.reduce<(typeof candidates)[number] | undefined>((best, j) => {
+        const jDep = new Date(j.legs[0]?.plannedDeparture ?? j.legs[0]?.departure ?? 0).getTime();
+        const jDiff = Math.abs(jDep - departure.getTime());
+        if (!best) return j;
+        const bestDep = new Date(best.legs[0]?.plannedDeparture ?? best.legs[0]?.departure ?? 0).getTime();
+        const bestDiff = Math.abs(bestDep - departure.getTime());
+        return jDiff < bestDiff ? j : best;
+      }, undefined);
+
+      if (matchingJourney) {
+        await context.entities.Journey.build(UpdateItemCommand)
+          .item({ userId: dbJourney.userId, id: dbJourney.id, refreshToken: matchingJourney.refreshToken! })
+          .send();
+        hafasJourney = matchingJourney;
+        Logger.info(`Successfully recovered journey ${dbJourney.id} with new refresh token`);
+      } else {
+        Logger.warn(`No matching journey found during recovery for journey ${dbJourney.id}`);
+      }
+    } catch (recoveryError) {
+      Logger.error(`Journey recovery failed for ${dbJourney.id}: ${recoveryError}`);
+    }
+  }
+
+  if (!hafasJourney) {
+    throw new Error(`Could not retrieve journey data for ${dbJourney.id}`);
+  }
+
   return {
     id: dbJourney.id,
     userId: dbJourney.userId,
     limitPrice: dbJourney.limitPrice,
     expires: dbJourney.expires,
-    from: journey?.legs[0].origin?.name ?? undefined,
-    to: journey ? (journey.legs[journey.legs.length - 1].destination?.name ?? undefined) : undefined,
+    from: hafasJourney.legs[0].origin?.name ?? undefined,
+    to: hafasJourney.legs[hafasJourney.legs.length - 1].destination?.name ?? undefined,
     firstClass: dbJourney.firstClass ?? undefined,
     bike: dbJourney.bike ?? undefined,
     deutschlandTicketDiscount: dbJourney.deutschlandTicketDiscount ?? undefined,
     ageGroup: (dbJourney.ageGroup as AgeGroup | undefined) ?? undefined,
     loyaltyCard: parseLoyaltyCard(dbJourney.loyaltyCard) ?? undefined,
-    journey: !journey
-      ? undefined
-      : {
-          refreshToken: journey.refreshToken!,
-          departure: new Date(journey.legs[0].plannedDeparture!),
-          arrival: new Date(journey.legs[journey.legs.length - 1].plannedArrival!),
-          means: getMeans(journey),
-          price: journey.price?.amount,
-        },
+    journey: {
+      refreshToken: hafasJourney.refreshToken!,
+      departure: new Date(hafasJourney.legs[0].plannedDeparture!),
+      arrival: new Date(hafasJourney.legs[hafasJourney.legs.length - 1].plannedArrival!),
+      means: getMeans(hafasJourney),
+      price: hafasJourney.price?.amount,
+    },
   };
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -17,6 +17,7 @@
       "db-vendo-client": ["./node_modules/hafas-client/index.d.ts"],
       "db-vendo-client/p/dbnav/index.js": ["./types/db-vendo-client/index.d.ts"],
       "db-vendo-client/p/db/index.js": ["./types/db-vendo-client/index.d.ts"],
+      "db-vendo-client/p/dbweb/index.js": ["./types/db-vendo-client/index.d.ts"],
       "db-hafas-stations": ["./types/db-hafas-stations/index.d.ts"]
     }
   },

--- a/backend/types/db-vendo-client/index.d.ts
+++ b/backend/types/db-vendo-client/index.d.ts
@@ -12,6 +12,11 @@ declare module 'db-vendo-client/p/db/index.js' {
   export const profile: Profile;
 }
 
+declare module 'db-vendo-client/p/dbweb/index.js' {
+  import type { Profile } from 'hafas-client';
+  export const profile: Profile;
+}
+
 declare module 'db-vendo-client/format/loyalty-cards.js' {
   export const data: {
     NONE: symbol;

--- a/backend/types/db-vendo-client/index.d.ts
+++ b/backend/types/db-vendo-client/index.d.ts
@@ -17,6 +17,16 @@ declare module 'db-vendo-client/p/dbweb/index.js' {
   export const profile: Profile;
 }
 
+declare module 'db-vendo-client/parse/journey-leg.js' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export function parseJourneyLeg(ctx: any, pt: any, date: any, fallbackLocations: any): any;
+}
+
+declare module 'db-vendo-client/parse/stopover.js' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export function parseStopover(ctx: any, st: any, date: any): any;
+}
+
 declare module 'db-vendo-client/format/loyalty-cards.js' {
   export const data: {
     NONE: symbol;

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -41,7 +41,9 @@ export const theme = createTheme({
       light: '#F9E0E0',
     },
     warning: {
-      main: '#FEFFD3',
+      main: '#b76e00',
+      light: '#e9a040',
+      dark: '#7d4900',
     },
     info: {
       main: '#5b7a9e',


### PR DESCRIPTION
## Summary

When the Lambda is unavailable for more than ~24 hours, all stored HAFAS refresh tokens expire. This PR adds token recovery to the HTTP watchlist path so that journeys can be re-resolved on the next page load instead of showing "No longer tracked" indefinitely.

## Changes

### `backend/src/managers/DbHafasManager.ts`

- **Switched HAFAS profile from `p/db` to `p/dbweb`** (`int.bahn.de`) to bypass the Akamai bot-protection block that was rejecting requests to `api.bahn.de`. This is a significant endpoint change: the dbweb `/angebote/recon` refresh endpoint returns departure/arrival times as nested objects (`abfahrt.sollzeit`) rather than flat string fields expected by the db-vendo-client parser.
- **Added `normalizeStopTimes` / `normalizeLegTimes` normalizers** to map the nested `{ abfahrt: { sollzeit, istzeit }, ankunft: ... }` structure to the flat `abgangsDatum` / `ezAbgangsDatum` / `ankunftsDatum` / `ezAnkunftsDatum` fields that the parser reads. Without this, all departure/arrival times parse as epoch zero.
- **Added `customDbProfile`** wrapping `parseJourneyLeg` and `parseStopover` to apply the normalizer before each parse call. Typed as `typeof dbProfile & { parseJourneyLeg: ...; parseStopover: ... }` to catch future upstream signature changes at compile time.

### `backend/src/resolvers/user.ts`

- **Added `departure: string`** to the `dbJourney` parameter type in `getJourneyMonitor` and the `journeyMonitors` resolver map callback. The field is already persisted in DynamoDB but was absent from the TypeScript type, making recovery impossible without a cast.
- **Added `import type { Journey as HafasJourney } from 'hafas-client'`** for explicit typing of the recovered journey variable.
- **Rewrote `getJourneyMonitor`** with two-stage resolution:
  1. Try `requeryJourney` with the stored refresh token. If it throws (HAFAS `NOT_FOUND` for an expired token), catch and log a warning rather than propagating.
  2. If no journey was obtained, fall back to re-querying HAFAS by `fromId + toId + departure` with all stored pricing options (`firstClass`, `loyaltyCard`, `ageGroup`, `bike`, `deutschlandTicketDiscount`). Find the closest match by departure time (identical algorithm to the existing recovery in `updateJourneyMonitor`). If a match is found, update the DynamoDB `refreshToken` and return the live journey data.
  3. If both stages fail, throw — the outer `journeyMonitors` catch returns a graceful `journey: undefined` fallback so the card is still displayed with station names.
- **Switched `notifications` resolver from `Promise.all` to `Promise.allSettled`** — consistent with the `journeyMonitors` resolver and bringing the same resilience: a single failing notification mapping no longer rejects the entire query. Failed notifications are filtered out with a structured error log (including notification id, type, and userId) rather than surfacing as a GraphQL error.

The SQS `updateJourneyMonitor` path already contained equivalent refresh-token recovery logic; this PR brings the HTTP path to parity.

## Verification

- `npm run typecheck` — passed (no errors)
- `npm run lint` — passed (no errors)
- Pre-commit hooks (Prettier, ESLint, trailing whitespace, line endings) — all passed